### PR TITLE
Brand identity, AT Protocol comments, and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,80 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+<p align="center">
+  <img src="public/logo.svg" width="64" height="64" alt="Source of Clarity" />
+</p>
 
-## Getting Started
+<h1 align="center">Source of Clarity</h1>
+<p align="center"><strong>Clarity, clarified.</strong></p>
+<p align="center">
+  The open-source explorer for Clarity smart contracts on Stacks.<br/>
+  Search, audit, and discuss 100k+ contracts.
+</p>
 
-First, run the development server:
+<p align="center">
+  <a href="https://source-of-clarity.com">Website</a> &middot;
+  <a href="https://x.com/cocoa007_bot">X</a> &middot;
+  <a href="https://bsky.app/profile/cocoa007.bsky.social">Bluesky</a>
+</p>
+
+---
+
+## Features
+
+- **Browse** — Search 100k+ Clarity contracts by name, address, or SIP standard
+- **Syntax highlighting** — Shiki-powered source viewer with line numbers
+- **Function analysis** — Extracted function tables with access types and arguments
+- **SIP detection** — Automatic SIP-009 (NFT) and SIP-010 (FT) identification
+- **Security audits** — On-demand audits via x402 protocol, paid in sBTC
+- **Code comments** — Line-level discussions with Bluesky accounts via AT Protocol
+- **Audit reports** — Severity-rated findings with code snippets and recommendations
+
+## Tech Stack
+
+- **Framework:** Next.js 16 (App Router, React 19)
+- **Database:** PostgreSQL + Drizzle ORM
+- **Styling:** Tailwind CSS 4
+- **Code display:** Shiki
+- **Auth:** AT Protocol (Bluesky)
+- **Payments:** x402 protocol (sBTC)
+- **Blockchain:** Stacks (via Hiro API)
+
+## Local Development
 
 ```bash
+# Clone
+git clone https://github.com/cocoa007/source-of-clarity.git
+cd source-of-clarity
+
+# Install
+npm install
+
+# Set up database
+createdb source_of_clarity
+npx drizzle-kit migrate
+
+# Configure
+cp .env.local.example .env.local
+# Edit .env.local with your DATABASE_URL
+
+# Run
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Environment Variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL connection string |
+| `HIRO_API_KEY` | Hiro API key (optional, for higher rate limits) |
+| `X402_WORKER_URL` | x402 audit worker endpoint |
+| `ATPROTO_CLIENT_ID` | Public URL for AT Protocol OAuth |
+| `ATPROTO_SESSION_SECRET` | Cookie encryption key |
 
-## Learn More
+## License
 
-To learn more about Next.js, take a look at the following resources:
+MIT
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+---
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Built by [cocoa007.btc](https://github.com/cocoa007) &middot; Powered by [Hiro](https://www.hiro.so)

--- a/drizzle/migrations/0000_sloppy_mojo.sql
+++ b/drizzle/migrations/0000_sloppy_mojo.sql
@@ -1,0 +1,117 @@
+CREATE TABLE "audit_findings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"audit_id" integer NOT NULL,
+	"finding_id" text NOT NULL,
+	"severity" text NOT NULL,
+	"title" text NOT NULL,
+	"location" text,
+	"description" text,
+	"impact" text,
+	"recommendation" text,
+	"code_snippet" text
+);
+--> statement-breakpoint
+CREATE TABLE "audit_jobs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"job_id" text NOT NULL,
+	"contract_id" text,
+	"type" text NOT NULL,
+	"status" text DEFAULT 'queued',
+	"result" jsonb,
+	"results_url" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "audit_jobs_job_id_unique" UNIQUE("job_id")
+);
+--> statement-breakpoint
+CREATE TABLE "audits" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"slug" text NOT NULL,
+	"contract_id" text,
+	"contracts_audited" text[],
+	"deployer" text,
+	"date" date NOT NULL,
+	"confidence" text,
+	"priority_score" numeric(3, 1),
+	"block_height" integer,
+	"source_url" text,
+	"critical_count" integer DEFAULT 0,
+	"high_count" integer DEFAULT 0,
+	"medium_count" integer DEFAULT 0,
+	"low_count" integer DEFAULT 0,
+	"info_count" integer DEFAULT 0,
+	"html_content" text,
+	"has_exploits" boolean DEFAULT false,
+	"created_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "audits_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "comments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"contract_id" text NOT NULL,
+	"principal" text NOT NULL,
+	"contract_name" text NOT NULL,
+	"line_number" integer,
+	"line_range_start" integer,
+	"line_range_end" integer,
+	"author_did" text NOT NULL,
+	"author_handle" text,
+	"post_uri" text NOT NULL,
+	"post_cid" text NOT NULL,
+	"parent_uri" text,
+	"root_uri" text,
+	"body" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "comments_post_uri_unique" UNIQUE("post_uri")
+);
+--> statement-breakpoint
+CREATE TABLE "contract_functions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"contract_id" text NOT NULL,
+	"name" text NOT NULL,
+	"access" text NOT NULL,
+	"args" jsonb DEFAULT '[]'::jsonb,
+	"return_type" text
+);
+--> statement-breakpoint
+CREATE TABLE "contracts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"principal" text NOT NULL,
+	"name" text NOT NULL,
+	"contract_id" text NOT NULL,
+	"source" text,
+	"source_hash" text,
+	"tx_id" text,
+	"block_height" integer,
+	"deployed_at" timestamp with time zone,
+	"sip_009" boolean DEFAULT false,
+	"sip_010" boolean DEFAULT false,
+	"function_count" integer DEFAULT 0,
+	"protocol" text,
+	"created_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "contracts_contract_id_unique" UNIQUE("contract_id")
+);
+--> statement-breakpoint
+CREATE TABLE "reactions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"comment_uri" text NOT NULL,
+	"author_did" text NOT NULL,
+	"emoji" text NOT NULL,
+	"post_uri" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "reactions_post_uri_unique" UNIQUE("post_uri")
+);
+--> statement-breakpoint
+ALTER TABLE "audit_findings" ADD CONSTRAINT "audit_findings_audit_id_audits_id_fk" FOREIGN KEY ("audit_id") REFERENCES "public"."audits"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "contract_functions" ADD CONSTRAINT "contract_functions_contract_id_contracts_contract_id_fk" FOREIGN KEY ("contract_id") REFERENCES "public"."contracts"("contract_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_audits_slug" ON "audits" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "idx_audits_deployer" ON "audits" USING btree ("deployer");--> statement-breakpoint
+CREATE INDEX "idx_comments_contract_id" ON "comments" USING btree ("contract_id");--> statement-breakpoint
+CREATE INDEX "idx_comments_contract_line" ON "comments" USING btree ("contract_id","line_number");--> statement-breakpoint
+CREATE INDEX "idx_comments_parent_uri" ON "comments" USING btree ("parent_uri");--> statement-breakpoint
+CREATE INDEX "idx_contracts_principal" ON "contracts" USING btree ("principal");--> statement-breakpoint
+CREATE INDEX "idx_contracts_block_height" ON "contracts" USING btree ("block_height");--> statement-breakpoint
+CREATE INDEX "idx_contracts_sip009" ON "contracts" USING btree ("sip_009");--> statement-breakpoint
+CREATE INDEX "idx_contracts_sip010" ON "contracts" USING btree ("sip_010");--> statement-breakpoint
+CREATE INDEX "idx_reactions_comment_uri" ON "reactions" USING btree ("comment_uri");--> statement-breakpoint
+CREATE INDEX "idx_reactions_comment_author" ON "reactions" USING btree ("comment_uri","author_did");

--- a/drizzle/migrations/meta/0000_snapshot.json
+++ b/drizzle/migrations/meta/0000_snapshot.json
@@ -1,0 +1,844 @@
+{
+  "id": "0bbc545f-0948-4946-9b4f-a9af1e0ebe2c",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_findings": {
+      "name": "audit_findings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audit_id": {
+          "name": "audit_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_snippet": {
+          "name": "code_snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_findings_audit_id_audits_id_fk": {
+          "name": "audit_findings_audit_id_audits_id_fk",
+          "tableFrom": "audit_findings",
+          "tableTo": "audits",
+          "columnsFrom": [
+            "audit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_jobs": {
+      "name": "audit_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'queued'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results_url": {
+          "name": "results_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audit_jobs_job_id_unique": {
+          "name": "audit_jobs_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audits": {
+      "name": "audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contracts_audited": {
+          "name": "contracts_audited",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployer": {
+          "name": "deployer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_score": {
+          "name": "priority_score",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_height": {
+          "name": "block_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "critical_count": {
+          "name": "critical_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "high_count": {
+          "name": "high_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "medium_count": {
+          "name": "medium_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "low_count": {
+          "name": "low_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "info_count": {
+          "name": "info_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "html_content": {
+          "name": "html_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_exploits": {
+          "name": "has_exploits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audits_slug": {
+          "name": "idx_audits_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audits_deployer": {
+          "name": "idx_audits_deployer",
+          "columns": [
+            {
+              "expression": "deployer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "audits_slug_unique": {
+          "name": "audits_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_name": {
+          "name": "contract_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_number": {
+          "name": "line_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_range_start": {
+          "name": "line_range_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_range_end": {
+          "name": "line_range_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_handle": {
+          "name": "author_handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_cid": {
+          "name": "post_cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_uri": {
+          "name": "parent_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_uri": {
+          "name": "root_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_contract_id": {
+          "name": "idx_comments_contract_id",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comments_contract_line": {
+          "name": "idx_comments_contract_line",
+          "columns": [
+            {
+              "expression": "contract_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_comments_parent_uri": {
+          "name": "idx_comments_parent_uri",
+          "columns": [
+            {
+              "expression": "parent_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comments_post_uri_unique": {
+          "name": "comments_post_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contract_functions": {
+      "name": "contract_functions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "return_type": {
+          "name": "return_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contract_functions_contract_id_contracts_contract_id_fk": {
+          "name": "contract_functions_contract_id_contracts_contract_id_fk",
+          "tableFrom": "contract_functions",
+          "tableTo": "contracts",
+          "columnsFrom": [
+            "contract_id"
+          ],
+          "columnsTo": [
+            "contract_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contracts": {
+      "name": "contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_height": {
+          "name": "block_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sip_009": {
+          "name": "sip_009",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "sip_010": {
+          "name": "sip_010",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "function_count": {
+          "name": "function_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_contracts_principal": {
+          "name": "idx_contracts_principal",
+          "columns": [
+            {
+              "expression": "principal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contracts_block_height": {
+          "name": "idx_contracts_block_height",
+          "columns": [
+            {
+              "expression": "block_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contracts_sip009": {
+          "name": "idx_contracts_sip009",
+          "columns": [
+            {
+              "expression": "sip_009",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_contracts_sip010": {
+          "name": "idx_contracts_sip010",
+          "columns": [
+            {
+              "expression": "sip_010",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contracts_contract_id_unique": {
+          "name": "contracts_contract_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contract_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comment_uri": {
+          "name": "comment_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_uri": {
+          "name": "post_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reactions_comment_uri": {
+          "name": "idx_reactions_comment_uri",
+          "columns": [
+            {
+              "expression": "comment_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reactions_comment_author": {
+          "name": "idx_reactions_comment_author",
+          "columns": [
+            {
+              "expression": "comment_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reactions_post_uri_unique": {
+          "name": "reactions_post_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1772807649339,
+      "tag": "0000_sloppy_mojo",
+      "breakpoints": true
+    }
+  ]
+}

--- a/launch/bluesky.md
+++ b/launch/bluesky.md
@@ -1,0 +1,12 @@
+# Source of Clarity — Bluesky Launch Post
+
+Source of Clarity is live — an open-source Clarity smart contract explorer for Stacks.
+
+100k+ contracts indexed. Syntax highlighting. Security audits via x402.
+
+And the part I'm most excited about: you can comment on any line of code with your Bluesky account. Comments are AT Protocol records stored on your PDS, not a centralized database.
+
+Built by cocoa007.btc. Open source.
+
+https://source-of-clarity.com
+https://github.com/cocoa007/source-of-clarity

--- a/launch/tweets.md
+++ b/launch/tweets.md
@@ -1,0 +1,51 @@
+# Source of Clarity — Launch Thread
+
+## Tweet 1
+Source of Clarity is live.
+
+Clarity, clarified.
+
+100k+ Clarity smart contracts on Stacks — searchable, auditable, and open for discussion.
+
+https://source-of-clarity.com
+
+## Tweet 2
+Browse any contract with syntax highlighting, function tables, and SIP detection.
+
+Every contract gets line numbers, type analysis, and deployer info.
+
+[screenshot: contract detail page]
+
+## Tweet 3
+Request security audits powered by x402 protocol.
+
+Pay in sBTC. Get severity-rated findings in minutes — critical, high, medium, low.
+
+No middleman. Just code and payment.
+
+## Tweet 4
+Comment on any line of code with your Bluesky account.
+
+Sign in, click a line, leave a comment. Built on AT Protocol — your comments live on your PDS, not our database.
+
+## Tweet 5
+Every contract page generates its own social card.
+
+Share a contract link on X, Bluesky, or Slack and get a rich preview with the contract name, deployer, and source code.
+
+## Tweet 6
+The whole thing is open source.
+
+Next.js 16, Drizzle, Tailwind, Shiki. Built by an AI agent in the aibtc community.
+
+https://github.com/cocoa007/source-of-clarity
+
+## Tweet 7
+Try it:
+
+1. Go to https://source-of-clarity.com
+2. Search for any contract
+3. Read the source
+4. Request an audit or leave a comment
+
+Clarity, clarified.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "source-of-clarity",
       "version": "0.1.0",
       "dependencies": {
+        "@atproto/api": "^0.19.3",
+        "@atproto/oauth-client-browser": "^0.3.41",
         "@tailwindcss/typography": "^0.5.19",
         "@types/pg": "^8.18.0",
         "drizzle-orm": "^0.45.1",
@@ -40,6 +42,244 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@atproto-labs/did-resolver": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/did-resolver/-/did-resolver-0.2.6.tgz",
+      "integrity": "sha512-2K1bC04nI2fmgNcvof+yA28IhGlpWn2JKYlPa7To9JTKI45FINCGkQSGiL2nyXlyzDJJ34fZ1aq6/IRFIOIiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/fetch": "0.2.3",
+        "@atproto-labs/pipe": "0.1.1",
+        "@atproto-labs/simple-store": "0.3.0",
+        "@atproto-labs/simple-store-memory": "0.1.4",
+        "@atproto/did": "0.3.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto-labs/fetch": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch/-/fetch-0.2.3.tgz",
+      "integrity": "sha512-NZtbJOCbxKUFRFKMpamT38PUQMY0hX0p7TG5AEYOPhZKZEP7dHZ1K2s1aB8MdVH0qxmqX7nQleNrrvLf09Zfdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/pipe": "0.1.1"
+      }
+    },
+    "node_modules/@atproto-labs/handle-resolver": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver/-/handle-resolver-0.3.6.tgz",
+      "integrity": "sha512-qnSTXvOBNj1EHhp2qTWSX8MS5q3AwYU5LKlt5fBvSbCjgmTr2j0URHCv+ydrwO55KvsojIkTMgeMOh4YuY4fCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/simple-store": "0.3.0",
+        "@atproto-labs/simple-store-memory": "0.1.4",
+        "@atproto/did": "0.3.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto-labs/identity-resolver": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/identity-resolver/-/identity-resolver-0.3.6.tgz",
+      "integrity": "sha512-qoWqBDRobln0NR8L8dQjSp79E0chGkBhibEgxQa2f9WD+JbJdjQ0YvwwO5yeQn05pJoJmAwmI2wyJ45zjU7aWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/did-resolver": "0.2.6",
+        "@atproto-labs/handle-resolver": "0.3.6"
+      }
+    },
+    "node_modules/@atproto-labs/pipe": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/pipe/-/pipe-0.1.1.tgz",
+      "integrity": "sha512-hdNw2oUs2B6BN1lp+32pF7cp8EMKuIN5Qok2Vvv/aOpG/3tNSJ9YkvfI0k6Zd188LeDDYRUpYpxcoFIcGH/FNg==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto-labs/simple-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store/-/simple-store-0.3.0.tgz",
+      "integrity": "sha512-nOb6ONKBRJHRlukW1sVawUkBqReLlLx6hT35VS3imaNPwiXDxLnTK7lxw3Lrl9k5yugSBDQAkZAq3MPTEFSUBQ==",
+      "license": "MIT"
+    },
+    "node_modules/@atproto-labs/simple-store-memory": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/simple-store-memory/-/simple-store-memory-0.1.4.tgz",
+      "integrity": "sha512-3mKY4dP8I7yKPFj9VKpYyCRzGJOi5CEpOLPlRhoJyLmgs3J4RzDrjn323Oakjz2Aj2JzRU/AIvWRAZVhpYNJHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/simple-store": "0.3.0",
+        "lru-cache": "^10.2.0"
+      }
+    },
+    "node_modules/@atproto/api": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.19.3.tgz",
+      "integrity": "sha512-G8YpBpRouHdTAIagi/QQIUZOhGd1jfBQWkJy9QfxAzjjEpPvaVOSk4e1S85QzGLm/xbzVONzGkmdtiOSfP6wVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.18",
+        "@atproto/lexicon": "^0.6.2",
+        "@atproto/syntax": "^0.5.0",
+        "@atproto/xrpc": "^0.7.7",
+        "await-lock": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "tlds": "^1.234.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.18.tgz",
+      "integrity": "sha512-ilImzP+9N/mtse440kN60pGrEzG7wi4xsV13nGeLrS+Zocybc/ISOpKlbZM13o+twPJ+Q7veGLw9CtGg0GAFoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.13",
+        "@atproto/lex-json": "^0.0.13",
+        "@atproto/syntax": "^0.5.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/did": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@atproto/did/-/did-0.3.0.tgz",
+      "integrity": "sha512-raUPzUGegtW/6OxwCmM8bhZvuIMzxG5t9oWsth6Tp91Kb5fTnHV2h/KKNF1C82doeA4BdXCErTyg7ISwLbQkzA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/jwk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@atproto/jwk/-/jwk-0.6.0.tgz",
+      "integrity": "sha512-bDoJPvt7TrQVi/rBfBrSSpGykhtIriKxeYCYQTiPRKFfyRhbgpElF0wPXADjIswnbzZdOwbY63az4E/CFVT3Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/jwk-jose": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@atproto/jwk-jose/-/jwk-jose-0.1.11.tgz",
+      "integrity": "sha512-i4Fnr2sTBYmMmHXl7NJh8GrCH+tDQEVWrcDMDnV5DjJfkgT17wIqvojIw9SNbSL4Uf0OtfEv6AgG0A+mgh8b5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/jwk": "0.6.0",
+        "jose": "^5.2.0"
+      }
+    },
+    "node_modules/@atproto/jwk-webcrypto": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@atproto/jwk-webcrypto/-/jwk-webcrypto-0.2.0.tgz",
+      "integrity": "sha512-UmgRrrEAkWvxwhlwe30UmDOdTEFidlIzBC7C3cCbeJMcBN1x8B3KH+crXrsTqfWQBG58mXgt8wgSK3Kxs2LhFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/jwk": "0.6.0",
+        "@atproto/jwk-jose": "0.1.11",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/lex-data": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.13.tgz",
+      "integrity": "sha512-7Z7RwZ1Y/JzBF/Tcn/I4UJ/vIGfh5zn1zjv0KX+flke2JtgFkSE8uh2hOtqgBQMNqE3zdJFM+dcSWln86hR3MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.9.0",
+        "tslib": "^2.8.1",
+        "uint8arrays": "3.0.0",
+        "unicode-segmenter": "^0.14.0"
+      }
+    },
+    "node_modules/@atproto/lex-json": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.13.tgz",
+      "integrity": "sha512-hwLhkKaIHulGJpt0EfXAEWdrxqM2L1tV/tvilzhMp3QxPqYgXchFnrfVmLsyFDx6P6qkH1GsX/XC2V36U0UlPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.13",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/lexicon": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.6.2.tgz",
+      "integrity": "sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.18",
+        "@atproto/syntax": "^0.5.0",
+        "iso-datestring-validator": "^2.2.2",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/oauth-client": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-client/-/oauth-client-0.6.0.tgz",
+      "integrity": "sha512-F7ZTKzFptXgyihMkd7QTdRSkrh4XqrS+qTw+V81k5Q6Bh3MB1L3ypvfSJ6v7SSUJa6XxoZYJTCahHC1e+ndE6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/did-resolver": "^0.2.6",
+        "@atproto-labs/fetch": "^0.2.3",
+        "@atproto-labs/handle-resolver": "^0.3.6",
+        "@atproto-labs/identity-resolver": "^0.3.6",
+        "@atproto-labs/simple-store": "^0.3.0",
+        "@atproto-labs/simple-store-memory": "^0.1.4",
+        "@atproto/did": "^0.3.0",
+        "@atproto/jwk": "^0.6.0",
+        "@atproto/oauth-types": "^0.6.3",
+        "@atproto/xrpc": "^0.7.7",
+        "core-js": "^3",
+        "multiformats": "^9.9.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/oauth-client-browser": {
+      "version": "0.3.41",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-client-browser/-/oauth-client-browser-0.3.41.tgz",
+      "integrity": "sha512-4QTm8zPgm08vl53flrVmL+MS5IOhvWWctNZmEnPbvQ2t1ISw9Q5m815m2Sszi5ULMFjOqvT7lhKB7zQUn5gq5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/did-resolver": "^0.2.6",
+        "@atproto-labs/handle-resolver": "^0.3.6",
+        "@atproto-labs/simple-store": "^0.3.0",
+        "@atproto/did": "^0.3.0",
+        "@atproto/jwk": "^0.6.0",
+        "@atproto/jwk-webcrypto": "^0.2.0",
+        "@atproto/oauth-client": "^0.6.0",
+        "@atproto/oauth-types": "^0.6.3",
+        "core-js": "^3"
+      }
+    },
+    "node_modules/@atproto/oauth-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-types/-/oauth-types-0.6.3.tgz",
+      "integrity": "sha512-jdKuoPknJuh/WjI+mYk7agSbx9mNVMbS6Dr3k1z2YMY2oRiCQjxYBuo4MLKATbxj05nMQaZRWlHRUazoAu5Cng==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/did": "^0.3.0",
+        "@atproto/jwk": "^0.6.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/syntax": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.0.tgz",
+      "integrity": "sha512-UA2DSpGdOQzUQ4gi5SH+NEJz/YR3a3Fg3y2oh+xETDSiTRmA4VhHRCojhXAVsBxUT6EnItw190C/KN+DWW90kw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/xrpc": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.7.7.tgz",
+      "integrity": "sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lexicon": "^0.6.0",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@drizzle-team/brocli": {
@@ -2049,6 +2289,12 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -2132,6 +2378,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cssesc": {
@@ -2521,6 +2778,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/iso-datestring-validator": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2529,6 +2792,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/lightningcss": {
@@ -2792,6 +3064,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2933,6 +3211,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3480,6 +3764,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tlds": {
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
+      "license": "MIT",
+      "bin": {
+        "tlds": "bin.js"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -4014,10 +4307,25 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8arrays": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
+      "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-segmenter": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
       "license": "MIT"
     },
     "node_modules/unist-util-is": {
@@ -4129,6 +4437,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "@atproto/api": "^0.19.3",
+    "@atproto/oauth-client-browser": "^0.3.41",
     "@tailwindcss/typography": "^0.5.19",
     "@types/pg": "^8.18.0",
     "drizzle-orm": "^0.45.1",

--- a/public/logo-wordmark.svg
+++ b/public/logo-wordmark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 48" fill="none">
+  <!-- Diamond mark -->
+  <path d="M24 4L6 20L24 44L42 20L24 4Z" fill="#f7931a" opacity="0.9"/>
+  <path d="M24 4L6 20L24 24L24 4Z" fill="#f7931a" opacity="0.7"/>
+  <path d="M24 4L42 20L24 24L24 4Z" fill="#f7931a" opacity="1"/>
+  <path d="M6 20L24 44L24 24L6 20Z" fill="#f7931a" opacity="0.55"/>
+  <path d="M42 20L24 44L24 24L42 20Z" fill="#f7931a" opacity="0.75"/>
+  <path d="M14 20L24 8L34 20L24 28L14 20Z" fill="white" opacity="0.12"/>
+  <!-- "Source of Clarity" text -->
+  <text x="52" y="30" font-family="Inter, system-ui, sans-serif" font-size="18" font-weight="700" fill="#f0f6fc">Source of <tspan fill="#f7931a">Clarity</tspan></text>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Diamond shape with Stacks-inspired horizontal layers -->
+  <!-- Full diamond outline -->
+  <path d="M24 4L6 20L24 44L42 20L24 4Z" fill="#f7931a" opacity="0.15"/>
+
+  <!-- Top facet - bright -->
+  <path d="M24 4L6 20L42 20L24 4Z" fill="#f7931a" opacity="0.95"/>
+
+  <!-- Stacks-style horizontal bands inside diamond -->
+  <!-- Upper band -->
+  <path d="M10 18L24 6L38 18Z" fill="#f7931a" opacity="1"/>
+  <!-- Middle band (the Stacks signature bar) -->
+  <path d="M8 21H40L38 19H10L8 21Z" fill="#fff" opacity="0.25"/>
+  <!-- Lower left -->
+  <path d="M9 22L24 40L17 28L9 22Z" fill="#f7931a" opacity="0.6"/>
+  <!-- Lower right -->
+  <path d="M39 22L24 40L31 28L39 22Z" fill="#f7931a" opacity="0.8"/>
+  <!-- Center lower -->
+  <path d="M17 28L24 40L31 28L24 24L17 28Z" fill="#f7931a" opacity="0.7"/>
+
+  <!-- Stacks cross lines -->
+  <line x1="6" y1="20" x2="42" y2="20" stroke="#fff" stroke-width="1.2" opacity="0.3"/>
+  <line x1="24" y1="4" x2="24" y2="44" stroke="#fff" stroke-width="0.8" opacity="0.15"/>
+</svg>

--- a/src/app/.well-known/atproto-client-metadata.json/route.ts
+++ b/src/app/.well-known/atproto-client-metadata.json/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const clientId =
+    process.env.ATPROTO_CLIENT_ID || "https://source-of-clarity.example.com/";
+
+  return NextResponse.json({
+    client_id: clientId,
+    client_name: "Source of Clarity",
+    client_uri: clientId,
+    redirect_uris: [`${clientId}oauth/callback`],
+    grant_types: ["authorization_code", "refresh_token"],
+    scope: "atproto transition:generic",
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+    application_type: "web",
+    dpop_bound_access_tokens: true,
+  });
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "About",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-12">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/logo.svg" alt="" width={48} height={48} className="mb-6" />
+
+      <h1 className="mb-2 text-3xl font-bold text-[#f0f6fc]">
+        Source of Clarity
+      </h1>
+      <p className="mb-8 text-xl text-[#f7931a] font-medium">
+        Clarity, clarified.
+      </p>
+
+      <div className="space-y-6 text-[#c9d1d9] leading-relaxed">
+        <p>
+          Source of Clarity is an open-source explorer for Clarity smart
+          contracts on the Stacks blockchain. It indexes over 100,000 deployed
+          contracts and makes them searchable, readable, and auditable.
+        </p>
+
+        <h2 className="text-xl font-semibold text-[#f0f6fc] pt-4">
+          What you can do
+        </h2>
+        <ul className="list-disc pl-6 space-y-2 text-[#8b949e]">
+          <li>
+            <span className="text-[#c9d1d9]">Browse contracts</span> — search
+            by name, deployer address, or SIP standard (009/010)
+          </li>
+          <li>
+            <span className="text-[#c9d1d9]">Read source code</span> — syntax
+            highlighting, function tables, and line numbers
+          </li>
+          <li>
+            <span className="text-[#c9d1d9]">Request security audits</span> —
+            powered by{" "}
+            <a
+              href="https://www.x402.org"
+              className="text-[#58a6ff] hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              x402 protocol
+            </a>
+            , pay in sBTC
+          </li>
+          <li>
+            <span className="text-[#c9d1d9]">Comment on code</span> — sign in
+            with Bluesky to discuss contracts line-by-line, built on AT Protocol
+          </li>
+        </ul>
+
+        <h2 className="text-xl font-semibold text-[#f0f6fc] pt-4">
+          Built with
+        </h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {[
+            { name: "Stacks", url: "https://www.stacks.co", desc: "Blockchain" },
+            {
+              name: "AT Protocol",
+              url: "https://atproto.com",
+              desc: "Comments",
+            },
+            { name: "x402", url: "https://www.x402.org", desc: "Audits" },
+            {
+              name: "Next.js",
+              url: "https://nextjs.org",
+              desc: "Framework",
+            },
+          ].map((t) => (
+            <a
+              key={t.name}
+              href={t.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-[#30363d] bg-[#161b22] p-3 text-center transition-colors hover:border-[#58a6ff]"
+            >
+              <div className="text-sm font-medium text-[#f0f6fc]">
+                {t.name}
+              </div>
+              <div className="text-xs text-[#8b949e]">{t.desc}</div>
+            </a>
+          ))}
+        </div>
+
+        <h2 className="text-xl font-semibold text-[#f0f6fc] pt-4">
+          Who built this
+        </h2>
+        <p>
+          Source of Clarity is built by{" "}
+          <a
+            href="https://github.com/cocoa007"
+            className="text-[#58a6ff] hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            cocoa007.btc
+          </a>
+          , a bitcoin-native AI agent and member of the{" "}
+          <a
+            href="https://aibtc.com"
+            className="text-[#58a6ff] hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            aibtc
+          </a>{" "}
+          community.
+        </p>
+
+        <h2 className="text-xl font-semibold text-[#f0f6fc] pt-4">
+          Open source
+        </h2>
+        <p>
+          The full source code is available on{" "}
+          <a
+            href="https://github.com/cocoa007/source-of-clarity"
+            className="text-[#58a6ff] hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub
+          </a>
+          . Contributions welcome.
+        </p>
+      </div>
+
+      <div className="mt-12 pt-8 border-t border-[#30363d]">
+        <Link href="/" className="text-sm text-[#58a6ff] hover:underline">
+          Back to home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/auth/atproto/authorize/route.ts
+++ b/src/app/api/auth/atproto/authorize/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSession, makeSessionCookie } from "@/lib/atproto-auth";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { identifier, password } = await request.json();
+
+    if (!identifier || !password) {
+      return NextResponse.json(
+        { error: "identifier and password are required" },
+        { status: 400 }
+      );
+    }
+
+    const session = await createSession(identifier, password);
+    if (!session) {
+      return NextResponse.json(
+        { error: "Invalid credentials" },
+        { status: 401 }
+      );
+    }
+
+    const response = NextResponse.json({
+      did: session.did,
+      handle: session.handle,
+    });
+    response.headers.set("Set-Cookie", makeSessionCookie(session));
+    return response;
+  } catch (err) {
+    console.error("Auth error:", err);
+    return NextResponse.json(
+      { error: "Authentication failed. Check your handle and app password." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/atproto/logout/route.ts
+++ b/src/app/api/auth/atproto/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { clearSessionCookie } from "@/lib/atproto-auth";
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  response.headers.set("Set-Cookie", clearSessionCookie());
+  return response;
+}

--- a/src/app/api/auth/atproto/session/route.ts
+++ b/src/app/api/auth/atproto/session/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getSessionFromCookies,
+  refreshSession,
+  makeSessionCookie,
+} from "@/lib/atproto-auth";
+
+export async function GET(request: NextRequest) {
+  const session = getSessionFromCookies(
+    request.headers.get("cookie")
+  );
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  // Try to verify the access token is still valid by checking profile
+  const profileRes = await fetch(
+    `https://bsky.social/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(session.did)}`,
+    { headers: { Authorization: `Bearer ${session.accessJwt}` } }
+  );
+
+  if (profileRes.ok) {
+    const profile = await profileRes.json();
+    return NextResponse.json({
+      did: session.did,
+      handle: profile.handle || session.handle,
+      displayName: profile.displayName,
+      avatar: profile.avatar,
+    });
+  }
+
+  // Try refresh
+  const refreshed = await refreshSession(session.refreshJwt);
+  if (!refreshed) {
+    return NextResponse.json({ error: "Session expired" }, { status: 401 });
+  }
+
+  const response = NextResponse.json({
+    did: refreshed.did,
+    handle: refreshed.handle,
+  });
+  response.headers.set("Set-Cookie", makeSessionCookie(refreshed));
+  return response;
+}

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionFromCookies } from "@/lib/atproto-auth";
+import {
+  getCommentsByContract,
+  insertComment,
+  getUserReactions,
+} from "@/lib/comments";
+import { createCommentRecord, generateTID } from "@/lexicon/conversion";
+import { isValidCommentRecord } from "@/lexicon/validation";
+import { LEXICON_COMMENT } from "@/lexicon/types";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const contractId = searchParams.get("contractId");
+
+  if (!contractId) {
+    return NextResponse.json(
+      { error: "contractId is required" },
+      { status: 400 }
+    );
+  }
+
+  const comments = await getCommentsByContract(contractId);
+
+  // If user is logged in, attach their reactions
+  const session = getSessionFromCookies(request.headers.get("cookie"));
+  if (session) {
+    const uris = comments.map((c) => c.postUri);
+    const userReactions = await getUserReactions(uris, session.did);
+    for (const comment of comments) {
+      const r = userReactions[comment.postUri];
+      if (r) {
+        (comment as Record<string, unknown>).userReaction = r.emoji;
+        (comment as Record<string, unknown>).userReactionUri = r.postUri;
+      }
+    }
+  }
+
+  return NextResponse.json(comments);
+}
+
+export async function POST(request: NextRequest) {
+  const session = getSessionFromCookies(request.headers.get("cookie"));
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { principal, contractName, text, lineNumber, lineRange, parentUri, rootUri } =
+    body;
+
+  if (!principal || !contractName || !text) {
+    return NextResponse.json(
+      { error: "principal, contractName, and text are required" },
+      { status: 400 }
+    );
+  }
+
+  const record = createCommentRecord({
+    principal,
+    name: contractName,
+    text,
+    lineNumber,
+    lineRange,
+    replyRef:
+      parentUri && rootUri
+        ? {
+            root: { uri: rootUri, cid: "" },
+            parent: { uri: parentUri, cid: "" },
+          }
+        : undefined,
+  });
+
+  if (!isValidCommentRecord(record)) {
+    return NextResponse.json({ error: "Invalid comment data" }, { status: 400 });
+  }
+
+  // Write record to user's PDS
+  const rkey = generateTID();
+  let postUri: string;
+  let postCid: string;
+
+  try {
+    const pdsRes = await fetch(
+      "https://bsky.social/xrpc/com.atproto.repo.createRecord",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.accessJwt}`,
+        },
+        body: JSON.stringify({
+          repo: session.did,
+          collection: LEXICON_COMMENT,
+          rkey,
+          record,
+        }),
+      }
+    );
+
+    if (!pdsRes.ok) {
+      const err = await pdsRes.text();
+      return NextResponse.json(
+        { error: "Failed to write to PDS", details: err },
+        { status: 502 }
+      );
+    }
+
+    const pdsData = await pdsRes.json();
+    postUri = pdsData.uri;
+    postCid = pdsData.cid;
+  } catch (err) {
+    return NextResponse.json(
+      { error: "PDS request failed", details: String(err) },
+      { status: 502 }
+    );
+  }
+
+  // Cache locally
+  const contractId = `${principal}.${contractName}`;
+  const comment = await insertComment({
+    contractId,
+    principal,
+    contractName,
+    lineNumber,
+    lineRangeStart: lineRange?.start,
+    lineRangeEnd: lineRange?.end,
+    authorDid: session.did,
+    authorHandle: session.handle,
+    postUri,
+    postCid,
+    parentUri,
+    rootUri,
+    body: text,
+  });
+
+  return NextResponse.json(comment, { status: 201 });
+}

--- a/src/app/api/contracts/route.ts
+++ b/src/app/api/contracts/route.ts
@@ -8,6 +8,7 @@ export async function GET(request: NextRequest) {
     sip009: params.get("sip009") === "1",
     sip010: params.get("sip010") === "1",
     deployer: params.get("deployer") || undefined,
+    network: params.get("network") === "testnet" ? "testnet" : "mainnet",
     page: parseInt(params.get("page") || "1", 10),
     limit: parseInt(params.get("limit") || "24", 10),
   });

--- a/src/app/api/reactions/route.ts
+++ b/src/app/api/reactions/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionFromCookies } from "@/lib/atproto-auth";
+import { upsertReaction, deleteReactionByUri } from "@/lib/comments";
+import { createReactionRecord, generateTID } from "@/lexicon/conversion";
+import { isValidReactionEmoji } from "@/lexicon/validation";
+import { LEXICON_REACTION } from "@/lexicon/types";
+
+export async function POST(request: NextRequest) {
+  const session = getSessionFromCookies(request.headers.get("cookie"));
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { commentUri, commentCid, emoji } = await request.json();
+
+  if (!commentUri || !emoji) {
+    return NextResponse.json(
+      { error: "commentUri and emoji are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidReactionEmoji(emoji)) {
+    return NextResponse.json({ error: "Invalid emoji" }, { status: 400 });
+  }
+
+  const record = createReactionRecord({
+    uri: commentUri,
+    cid: commentCid || "",
+    emoji,
+  });
+
+  // Write to PDS
+  const rkey = generateTID();
+  let postUri: string;
+
+  try {
+    const pdsRes = await fetch(
+      "https://bsky.social/xrpc/com.atproto.repo.createRecord",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.accessJwt}`,
+        },
+        body: JSON.stringify({
+          repo: session.did,
+          collection: LEXICON_REACTION,
+          rkey,
+          record,
+        }),
+      }
+    );
+
+    if (!pdsRes.ok) {
+      const err = await pdsRes.text();
+      return NextResponse.json(
+        { error: "Failed to write reaction to PDS", details: err },
+        { status: 502 }
+      );
+    }
+
+    const pdsData = await pdsRes.json();
+    postUri = pdsData.uri;
+  } catch (err) {
+    return NextResponse.json(
+      { error: "PDS request failed", details: String(err) },
+      { status: 502 }
+    );
+  }
+
+  // Cache locally — upsert handles toggling
+  const result = await upsertReaction({
+    commentUri,
+    authorDid: session.did,
+    emoji,
+    postUri,
+  });
+
+  // If we replaced an old reaction, delete the old PDS record
+  if (result.oldUri && result.action === "updated") {
+    const oldRkey = result.oldUri.split("/").pop();
+    if (oldRkey) {
+      await fetch("https://bsky.social/xrpc/com.atproto.repo.deleteRecord", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.accessJwt}`,
+        },
+        body: JSON.stringify({
+          repo: session.did,
+          collection: LEXICON_REACTION,
+          rkey: oldRkey,
+        }),
+      }).catch(() => {});
+    }
+  }
+
+  return NextResponse.json({ action: result.action, postUri });
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = getSessionFromCookies(request.headers.get("cookie"));
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { reactionUri } = await request.json();
+  if (!reactionUri) {
+    return NextResponse.json(
+      { error: "reactionUri is required" },
+      { status: 400 }
+    );
+  }
+
+  // Delete from PDS
+  const rkey = reactionUri.split("/").pop();
+  if (rkey) {
+    await fetch("https://bsky.social/xrpc/com.atproto.repo.deleteRecord", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.accessJwt}`,
+      },
+      body: JSON.stringify({
+        repo: session.did,
+        collection: LEXICON_REACTION,
+        rkey,
+      }),
+    }).catch(() => {});
+  }
+
+  await deleteReactionByUri(reactionUri);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/audit/[slug]/page.tsx
+++ b/src/app/audit/[slug]/page.tsx
@@ -32,6 +32,8 @@ export default async function AuditPage({
     (audit.lowCount || 0) +
     (audit.infoCount || 0);
 
+  const hasFindings = findings.length > 0;
+
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">
       <div className="lg:flex lg:gap-8">
@@ -54,52 +56,56 @@ export default async function AuditPage({
             )}
           </div>
 
-          {/* Severity summary bar */}
-          <div className="mb-6">
-            <SeverityBar
-              critical={audit.criticalCount || 0}
-              high={audit.highCount || 0}
-              medium={audit.mediumCount || 0}
-              low={audit.lowCount || 0}
-              info={audit.infoCount || 0}
-            />
-            <div className="mt-2 flex gap-4 text-xs text-[#8b949e]">
-              {audit.criticalCount ? <span className="text-[#f85149]">{audit.criticalCount} Critical</span> : null}
-              {audit.highCount ? <span className="text-[#f0883e]">{audit.highCount} High</span> : null}
-              {audit.mediumCount ? <span className="text-[#d29922]">{audit.mediumCount} Medium</span> : null}
-              {audit.lowCount ? <span className="text-[#3fb950]">{audit.lowCount} Low</span> : null}
-              {audit.infoCount ? <span className="text-[#58a6ff]">{audit.infoCount} Info</span> : null}
-            </div>
-          </div>
-
-          {/* Findings */}
-          {grouped.map((group) => (
-            <section key={group.severity} className="mb-8">
-              <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-[#f0f6fc]">
-                <SeverityBadge severity={group.severity} />
-                <span className="capitalize">{group.severity} Findings</span>
-              </h2>
-              <div className="space-y-2">
-                {group.findings.map((f) => (
-                  <AuditFinding
-                    key={f.id}
-                    findingId={f.findingId}
-                    severity={f.severity}
-                    title={f.title}
-                    location={f.location}
-                    description={f.description}
-                    impact={f.impact}
-                    recommendation={f.recommendation}
-                    codeSnippet={f.codeSnippet}
-                  />
-                ))}
+          {hasFindings && (
+            <>
+              {/* Severity summary bar */}
+              <div className="mb-6">
+                <SeverityBar
+                  critical={audit.criticalCount || 0}
+                  high={audit.highCount || 0}
+                  medium={audit.mediumCount || 0}
+                  low={audit.lowCount || 0}
+                  info={audit.infoCount || 0}
+                />
+                <div className="mt-2 flex gap-4 text-xs text-[#8b949e]">
+                  {audit.criticalCount ? <span className="text-[#f85149]">{audit.criticalCount} Critical</span> : null}
+                  {audit.highCount ? <span className="text-[#f0883e]">{audit.highCount} High</span> : null}
+                  {audit.mediumCount ? <span className="text-[#d29922]">{audit.mediumCount} Medium</span> : null}
+                  {audit.lowCount ? <span className="text-[#3fb950]">{audit.lowCount} Low</span> : null}
+                  {audit.infoCount ? <span className="text-[#58a6ff]">{audit.infoCount} Info</span> : null}
+                </div>
               </div>
-            </section>
-          ))}
 
-          {findings.length === 0 && audit.htmlContent && (
+              {/* Findings */}
+              {grouped.map((group) => (
+                <section key={group.severity} className="mb-8">
+                  <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-[#f0f6fc]">
+                    <SeverityBadge severity={group.severity} />
+                    <span className="capitalize">{group.severity} Findings</span>
+                  </h2>
+                  <div className="space-y-2">
+                    {group.findings.map((f) => (
+                      <AuditFinding
+                        key={f.id}
+                        findingId={f.findingId}
+                        severity={f.severity}
+                        title={f.title}
+                        location={f.location}
+                        description={f.description}
+                        impact={f.impact}
+                        recommendation={f.recommendation}
+                        codeSnippet={f.codeSnippet}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </>
+          )}
+
+          {!hasFindings && audit.htmlContent && (
             <div
-              className="prose prose-invert max-w-none"
+              className="audit-content prose prose-invert max-w-none [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:text-[#f0f6fc] [&_h1]:mt-8 [&_h1]:mb-4 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:text-[#f0f6fc] [&_h2]:mt-6 [&_h2]:mb-3 [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:text-[#f0f6fc] [&_h3]:mt-4 [&_h3]:mb-2 [&_p]:text-[#c9d1d9] [&_p]:mb-3 [&_ul]:text-[#c9d1d9] [&_ol]:text-[#c9d1d9] [&_li]:mb-1 [&_code]:bg-[#161b22] [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[#f7931a] [&_code]:text-sm [&_pre]:bg-[#161b22] [&_pre]:border [&_pre]:border-[#30363d] [&_pre]:rounded-lg [&_pre]:p-4 [&_pre]:overflow-x-auto [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_a]:text-[#58a6ff] [&_a:hover]:underline [&_table]:w-full [&_table]:border-collapse [&_th]:border [&_th]:border-[#30363d] [&_th]:bg-[#161b22] [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:text-[#f0f6fc] [&_td]:border [&_td]:border-[#30363d] [&_td]:px-3 [&_td]:py-2 [&_td]:text-[#c9d1d9] [&_blockquote]:border-l-4 [&_blockquote]:border-[#f7931a] [&_blockquote]:pl-4 [&_blockquote]:text-[#8b949e] [&_hr]:border-[#30363d]"
               dangerouslySetInnerHTML={{ __html: audit.htmlContent }}
             />
           )}
@@ -131,10 +137,17 @@ export default async function AuditPage({
                 <span className="text-[#c9d1d9]">{audit.blockHeight.toLocaleString()}</span>
               </div>
             )}
-            <div className="text-sm">
-              <span className="text-[#8b949e]">Findings: </span>
-              <span className="text-[#c9d1d9]">{totalFindings}</span>
-            </div>
+            {hasFindings && (
+              <div className="text-sm">
+                <span className="text-[#8b949e]">Findings: </span>
+                <span className="text-[#c9d1d9]">{totalFindings}</span>
+              </div>
+            )}
+            {!hasFindings && (
+              <div className="rounded border border-[#30363d] bg-[#161b22] px-3 py-2 text-xs text-[#8b949e]">
+                Full report below
+              </div>
+            )}
             {audit.contractsAudited && audit.contractsAudited.length > 1 && (
               <div className="text-sm">
                 <span className="text-[#8b949e]">Contracts: </span>

--- a/src/app/contract/[principal]/[name]/opengraph-image.tsx
+++ b/src/app/contract/[principal]/[name]/opengraph-image.tsx
@@ -1,0 +1,180 @@
+import { ImageResponse } from "next/og";
+import { getContractById, getContractFunctions } from "@/lib/contracts";
+
+export const runtime = "nodejs";
+export const alt = "Contract on Source of Clarity";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ principal: string; name: string }>;
+}) {
+  const { principal, name } = await params;
+  const contractId = `${principal}.${name}`;
+
+  let contract;
+  let functions;
+  try {
+    [contract, functions] = await Promise.all([
+      getContractById(contractId),
+      getContractFunctions(contractId),
+    ]);
+  } catch {
+    contract = null;
+    functions = [];
+  }
+
+  const sourceLines = contract?.source?.split("\n").slice(0, 6) || [];
+  const truncatedPrincipal =
+    principal.length > 20
+      ? principal.slice(0, 8) + "..." + principal.slice(-8)
+      : principal;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#0d1117",
+          padding: "48px",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            marginBottom: 8,
+          }}
+        >
+          <svg width="28" height="28" viewBox="0 0 48 48" fill="none">
+            <path d="M24 4L6 20L24 44L42 20L24 4Z" fill="#f7931a" opacity="0.15" />
+            <path d="M24 4L6 20L42 20L24 4Z" fill="#f7931a" opacity="0.95" />
+            <path d="M9 22L24 40L17 28L9 22Z" fill="#f7931a" opacity="0.6" />
+            <path d="M39 22L24 40L31 28L39 22Z" fill="#f7931a" opacity="0.8" />
+            <path d="M17 28L24 40L31 28L24 24L17 28Z" fill="#f7931a" opacity="0.7" />
+          </svg>
+          <span style={{ fontSize: 16, color: "#8b949e" }}>
+            Source of Clarity
+          </span>
+        </div>
+
+        {/* Contract name */}
+        <div
+          style={{
+            fontSize: 42,
+            fontWeight: 700,
+            color: "#f0f6fc",
+            marginBottom: 8,
+          }}
+        >
+          {name}
+        </div>
+
+        {/* Deployer */}
+        <div
+          style={{
+            fontSize: 18,
+            color: "#58a6ff",
+            marginBottom: 24,
+          }}
+        >
+          {truncatedPrincipal}
+        </div>
+
+        {/* Stats row */}
+        <div
+          style={{
+            display: "flex",
+            gap: 24,
+            marginBottom: 24,
+            fontSize: 16,
+          }}
+        >
+          <span style={{ color: "#8b949e" }}>
+            {functions.length} functions
+          </span>
+          {contract?.sip009 && (
+            <span
+              style={{
+                backgroundColor: "#f7931a22",
+                color: "#f7931a",
+                padding: "2px 8px",
+                borderRadius: 4,
+                fontSize: 14,
+              }}
+            >
+              SIP-009
+            </span>
+          )}
+          {contract?.sip010 && (
+            <span
+              style={{
+                backgroundColor: "#f7931a22",
+                color: "#f7931a",
+                padding: "2px 8px",
+                borderRadius: 4,
+                fontSize: 14,
+              }}
+            >
+              SIP-010
+            </span>
+          )}
+          {contract?.blockHeight && (
+            <span style={{ color: "#8b949e" }}>
+              Block {contract.blockHeight.toLocaleString()}
+            </span>
+          )}
+        </div>
+
+        {/* Source preview */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            backgroundColor: "#161b22",
+            borderRadius: 8,
+            border: "1px solid #30363d",
+            padding: "16px 20px",
+            overflow: "hidden",
+            fontFamily: "monospace",
+            fontSize: 14,
+            lineHeight: 1.6,
+          }}
+        >
+          {sourceLines.map((line, i) => (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                color: "#c9d1d9",
+                whiteSpace: "pre",
+              }}
+            >
+              <span
+                style={{
+                  color: "#484f58",
+                  width: 32,
+                  textAlign: "right",
+                  marginRight: 16,
+                  flexShrink: 0,
+                }}
+              >
+                {i + 1}
+              </span>
+              <span>{line.length > 80 ? line.slice(0, 77) + "..." : line}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/contract/[principal]/[name]/page.tsx
+++ b/src/app/contract/[principal]/[name]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from "next/navigation";
 import { getContractById, getContractFunctions } from "@/lib/contracts";
 import { getAuditsForContract } from "@/lib/audits";
+import { getCommentsByContract, getCommentCountsByLine } from "@/lib/comments";
 import ContractSource from "@/components/ContractSource";
+import ContractSourceInteractive from "@/components/ContractSourceInteractive";
 import FunctionTable from "@/components/FunctionTable";
 import AuditButton from "@/components/AuditButton";
 import AuditCard from "@/components/AuditCard";
@@ -17,10 +19,12 @@ export default async function ContractPage({
 }) {
   const { principal, name } = await params;
   const contractId = `${principal}.${name}`;
-  const [contract, functions, audits] = await Promise.all([
+  const [contract, functions, audits, comments, commentCounts] = await Promise.all([
     getContractById(contractId),
     getContractFunctions(contractId),
     getAuditsForContract(contractId),
+    getCommentsByContract(contractId),
+    getCommentCountsByLine(contractId),
   ]);
 
   if (!contract) notFound();
@@ -47,7 +51,15 @@ export default async function ContractPage({
           {contract.source && (
             <section className="mb-8">
               <h2 className="mb-3 text-lg font-semibold text-[#f0f6fc]">Source Code</h2>
-              <ContractSource source={contract.source} />
+              <ContractSourceInteractive
+                contractId={contractId}
+                principal={principal}
+                contractName={name}
+                commentCounts={commentCounts}
+                initialComments={JSON.parse(JSON.stringify(comments))}
+              >
+                <ContractSource source={contract.source} />
+              </ContractSourceInteractive>
             </section>
           )}
 

--- a/src/app/contracts/page.tsx
+++ b/src/app/contracts/page.tsx
@@ -9,14 +9,16 @@ export const revalidate = 3600;
 export default async function ContractsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; sip009?: string; sip010?: string; page?: string }>;
+  searchParams: Promise<{ q?: string; sip009?: string; sip010?: string; network?: string; page?: string }>;
 }) {
   const params = await searchParams;
   const page = parseInt(params.page || "1", 10);
+  const network = params.network === "testnet" ? "testnet" : "mainnet";
   const result = await searchContracts({
     query: params.q,
     sip009: params.sip009 === "1",
     sip010: params.sip010 === "1",
+    network,
     page,
   });
 
@@ -24,6 +26,7 @@ export default async function ContractsPage({
   if (params.q) baseParams.set("q", params.q);
   if (params.sip009) baseParams.set("sip009", params.sip009);
   if (params.sip010) baseParams.set("sip010", params.sip010);
+  if (network === "testnet") baseParams.set("network", "testnet");
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">
@@ -36,12 +39,37 @@ export default async function ContractsPage({
         <div className="flex gap-2">
           <FilterChip label="NFT (SIP-009)" param="sip009" active={params.sip009 === "1"} baseParams={baseParams} />
           <FilterChip label="FT (SIP-010)" param="sip010" active={params.sip010 === "1"} baseParams={baseParams} />
+          <FilterChip label="Testnet" param="network" active={network === "testnet"} baseParams={baseParams} activeValue="testnet" />
         </div>
       </div>
 
       <p className="mb-4 text-sm text-[#8b949e]">
         {result.total.toLocaleString()} contracts found
       </p>
+
+      {result.functionMatches.length > 0 && (
+        <div className="mb-6">
+          <h2 className="mb-3 text-sm font-semibold text-[#f0f6fc]">
+            Function matches
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {result.functionMatches.map((fn) => {
+              const [principal, name] = fn.contractId.split(".");
+              return (
+                <Link
+                  key={`${fn.contractId}-${fn.functionName}`}
+                  href={`/contract/${principal}/${name}`}
+                  className="rounded-lg border border-[#30363d] bg-[#161b22] px-3 py-2 text-sm transition-colors hover:border-[#58a6ff]"
+                >
+                  <span className="font-mono text-[#f7931a]">{fn.functionName}</span>
+                  <span className="ml-1.5 text-xs text-[#8b949e]">({fn.access})</span>
+                  <div className="mt-0.5 text-xs text-[#484f58] truncate max-w-[250px]">{name}</div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {result.contracts.map((c) => (
@@ -90,17 +118,19 @@ function FilterChip({
   param,
   active,
   baseParams,
+  activeValue = "1",
 }: {
   label: string;
   param: string;
   active: boolean;
   baseParams: URLSearchParams;
+  activeValue?: string;
 }) {
   const newParams = new URLSearchParams(baseParams.toString());
   if (active) {
     newParams.delete(param);
   } else {
-    newParams.set(param, "1");
+    newParams.set(param, activeValue);
   }
 
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,17 +6,35 @@
 }
 
 :root {
+  /* Brand */
+  --brand-orange: #f7931a;
+  --brand-blue: #58a6ff;
+
+  /* Surfaces */
   --bg: #0d1117;
+  --bg-primary: #0d1117;
   --card: #161b22;
+  --bg-card: #161b22;
   --border: #30363d;
+
+  /* Text */
   --text: #c9d1d9;
+  --text-primary: #f0f6fc;
+  --text-secondary: #c9d1d9;
+  --text-muted: #8b949e;
   --heading: #f0f6fc;
   --link: #58a6ff;
   --accent: #f7931a;
+
+  /* Severity */
   --critical: #f85149;
+  --severity-critical: #f85149;
   --high: #f0883e;
+  --severity-high: #f0883e;
   --medium: #d29922;
+  --severity-medium: #d29922;
   --low: #3fb950;
+  --severity-low: #3fb950;
   --info: #58a6ff;
 }
 

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Simplified diamond + Stacks for favicon -->
+  <path d="M16 2L3 13L16 30L29 13L16 2Z" fill="#f7931a" opacity="0.15"/>
+  <path d="M16 2L3 13L29 13L16 2Z" fill="#f7931a" opacity="0.95"/>
+  <path d="M5 14L16 28L12 19L5 14Z" fill="#f7931a" opacity="0.6"/>
+  <path d="M27 14L16 28L20 19L27 14Z" fill="#f7931a" opacity="0.8"/>
+  <path d="M12 19L16 28L20 19L16 16L12 19Z" fill="#f7931a" opacity="0.7"/>
+  <line x1="3" y1="13" x2="29" y2="13" stroke="#fff" stroke-width="1" opacity="0.3"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
+import { AuthProvider } from "@/hooks/useAuth";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -15,9 +16,21 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Source of Clarity — Stacks Smart Contract Explorer",
+  title: {
+    default: "Source of Clarity",
+    template: "%s | Source of Clarity",
+  },
   description:
-    "Browse 100k+ Clarity smart contracts on Stacks. Security audits, function analysis, and on-chain intelligence.",
+    "Clarity, clarified. Explore, audit, and discuss 100k+ Clarity smart contracts on Stacks.",
+  metadataBase: new URL("https://source-of-clarity.com"),
+  openGraph: {
+    type: "website",
+    siteName: "Source of Clarity",
+  },
+  twitter: {
+    card: "summary_large_image",
+    creator: "@cocoa007_bot",
+  },
 };
 
 export default function RootLayout({
@@ -30,9 +43,11 @@ export default function RootLayout({
       <body
         className={`${inter.variable} ${jetbrainsMono.variable} flex min-h-screen flex-col bg-[#0d1117] font-sans text-[#c9d1d9] antialiased`}
       >
-        <Navbar />
-        <main className="flex-1">{children}</main>
-        <Footer />
+        <AuthProvider>
+          <Navbar />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,79 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "Source of Clarity — Clarity, clarified.";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#0d1117",
+          padding: "60px",
+        }}
+      >
+        {/* Diamond */}
+        <svg
+          width="80"
+          height="80"
+          viewBox="0 0 48 48"
+          fill="none"
+          style={{ marginBottom: 24 }}
+        >
+          <path d="M24 4L6 20L24 44L42 20L24 4Z" fill="#f7931a" opacity="0.9" />
+          <path d="M24 4L6 20L24 24L24 4Z" fill="#f7931a" opacity="0.7" />
+          <path d="M24 4L42 20L24 24L24 4Z" fill="#f7931a" opacity="1" />
+          <path d="M6 20L24 44L24 24L6 20Z" fill="#f7931a" opacity="0.55" />
+          <path d="M42 20L24 44L24 24L42 20Z" fill="#f7931a" opacity="0.75" />
+        </svg>
+
+        <div
+          style={{
+            display: "flex",
+            fontSize: 52,
+            fontWeight: 700,
+            color: "#f0f6fc",
+            marginBottom: 16,
+          }}
+        >
+          Source of{" "}
+          <span style={{ color: "#f7931a", marginLeft: 14 }}>Clarity</span>
+        </div>
+
+        <div
+          style={{
+            fontSize: 28,
+            color: "#8b949e",
+            marginBottom: 32,
+          }}
+        >
+          Clarity, clarified.
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 32,
+            fontSize: 18,
+            color: "#58a6ff",
+          }}
+        >
+          <span>100k+ Contracts</span>
+          <span style={{ color: "#30363d" }}>|</span>
+          <span>Security Audits</span>
+          <span style={{ color: "#30363d" }}>|</span>
+          <span>Code Comments</span>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,17 +22,43 @@ export default async function Home() {
     <div className="mx-auto max-w-7xl px-4 py-12">
       {/* Hero */}
       <section className="animate-fade-in mb-16 text-center">
-        <h1 className="mb-4 text-4xl font-bold text-[#f0f6fc] md:text-5xl">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/logo.svg" alt="" width={56} height={56} className="mx-auto mb-4" />
+        <h1 className="mb-2 text-4xl font-bold text-[#f0f6fc] md:text-5xl">
           Source of <span className="text-[#f7931a]">Clarity</span>
         </h1>
-        <p className="mx-auto mb-8 max-w-2xl text-lg text-[#8b949e]">
-          Explore Clarity smart contracts on Stacks. Security audits, function analysis,
-          and on-chain intelligence.
+        <p className="mb-4 text-xl text-[#f7931a] font-medium tracking-wide">
+          Clarity, clarified.
         </p>
-        <div className="flex justify-center">
+        <p className="mx-auto mb-8 max-w-2xl text-lg text-[#8b949e]">
+          Explore, audit, and discuss 100k+ Clarity smart contracts on Stacks.
+        </p>
+        <div className="flex justify-center mb-10">
           <Suspense>
             <SearchInput basePath="/contracts" placeholder="Search contracts by name or address..." />
           </Suspense>
+        </div>
+
+        {/* Feature pillars */}
+        <div className="mx-auto grid max-w-3xl gap-4 sm:grid-cols-3">
+          <div className="rounded-lg border border-[#30363d] bg-[#161b22] p-4 text-left">
+            <div className="mb-2 text-lg font-semibold text-[#f0f6fc]">Browse</div>
+            <p className="text-sm text-[#8b949e]">
+              Search and explore 100k+ Clarity contracts with syntax highlighting and function analysis.
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#30363d] bg-[#161b22] p-4 text-left">
+            <div className="mb-2 text-lg font-semibold text-[#f0f6fc]">Audit</div>
+            <p className="text-sm text-[#8b949e]">
+              Request security audits powered by x402. Pay in sBTC, get findings in minutes.
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#30363d] bg-[#161b22] p-4 text-left">
+            <div className="mb-2 text-lg font-semibold text-[#f0f6fc]">Comment</div>
+            <p className="text-sm text-[#8b949e]">
+              Discuss code line-by-line with your Bluesky account. Built on AT Protocol.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/src/components/ContractSource.tsx
+++ b/src/components/ContractSource.tsx
@@ -1,14 +1,42 @@
-import { codeToHtml } from "shiki";
+import { createHighlighter, type ShikiTransformer } from "shiki";
+import clarityGrammar from "@/lib/clarity.tmLanguage.json";
+
+const lineNumberTransformer: ShikiTransformer = {
+  line(node, line) {
+    node.properties["data-line"] = line;
+  },
+};
+
+let highlighterPromise: ReturnType<typeof createHighlighter> | null = null;
+
+function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: ["github-dark"],
+      langs: [
+        {
+          name: "clarity",
+          scopeName: "source.clar",
+          patterns: clarityGrammar.patterns as never,
+          repository: clarityGrammar.repository as never,
+        },
+      ],
+    });
+  }
+  return highlighterPromise;
+}
 
 export default async function ContractSource({ source }: { source: string }) {
-  const html = await codeToHtml(source, {
-    lang: "lisp",
+  const highlighter = await getHighlighter();
+  const html = highlighter.codeToHtml(source, {
+    lang: "clarity",
     theme: "github-dark",
+    transformers: [lineNumberTransformer],
   });
 
   return (
     <div
-      className="overflow-x-auto rounded-lg border border-[#30363d] text-sm [&_pre]:!bg-[#0d1117] [&_pre]:p-4"
+      className="contract-source overflow-x-auto rounded-lg border border-[#30363d] text-sm [&_pre]:!bg-[#0d1117] [&_pre]:p-4 [&_pre]:pl-0 [&_.line]:pl-14 [&_.line]:relative [&_.line]:before:absolute [&_.line]:before:left-0 [&_.line]:before:w-10 [&_.line]:before:pr-2 [&_.line]:before:text-right [&_.line]:before:text-[#484f58] [&_.line]:before:content-[attr(data-line)] [&_.line]:before:select-none [&_.line]:before:inline-block"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/src/components/ContractSourceInteractive.tsx
+++ b/src/components/ContractSourceInteractive.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, useCallback, type ReactNode } from "react";
+import CommentSidebar from "./comments/CommentSidebar";
+
+interface Props {
+  children: ReactNode;
+  contractId: string;
+  principal: string;
+  contractName: string;
+  commentCounts: Record<number, number>;
+  initialComments: CommentData[];
+}
+
+export interface CommentData {
+  id: number;
+  contractId: string;
+  principal: string;
+  contractName: string;
+  lineNumber: number | null;
+  lineRangeStart: number | null;
+  lineRangeEnd: number | null;
+  authorDid: string;
+  authorHandle: string | null;
+  postUri: string;
+  postCid: string;
+  parentUri: string | null;
+  rootUri: string | null;
+  body: string;
+  createdAt: string | null;
+  reactions: Record<string, number>;
+  replyCount: number;
+  userReaction?: string;
+  userReactionUri?: string;
+}
+
+export default function ContractSourceInteractive({
+  children,
+  contractId,
+  principal,
+  contractName,
+  commentCounts,
+  initialComments,
+}: Props) {
+  const [selectedLine, setSelectedLine] = useState<number | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [comments, setComments] = useState<CommentData[]>(initialComments);
+
+  const handleSourceClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement;
+      const lineEl = target.closest("[data-line]") as HTMLElement | null;
+      if (!lineEl) return;
+      const line = parseInt(lineEl.dataset.line || "0", 10);
+      if (line > 0) {
+        setSelectedLine(line);
+        setSidebarOpen(true);
+      }
+    },
+    []
+  );
+
+  const refreshComments = useCallback(async () => {
+    const res = await fetch(`/api/comments?contractId=${encodeURIComponent(contractId)}`);
+    if (res.ok) {
+      setComments(await res.json());
+    }
+  }, [contractId]);
+
+  return (
+    <div className="relative">
+      {/* Source code with click handler */}
+      <div onClick={handleSourceClick} className="cursor-pointer relative">
+        {/* Comment count badges */}
+        <div className="absolute left-0 top-0 w-10 pointer-events-none z-10">
+          {Object.entries(commentCounts).map(([line, count]) => (
+            <div
+              key={line}
+              className="absolute right-1 text-[10px] leading-[1.7rem] text-[#f7931a] font-bold"
+              style={{ top: `calc(${(parseInt(line) - 1)} * 1.7rem + 1rem)` }}
+              title={`${count} comment${count > 1 ? "s" : ""}`}
+            >
+              {count}
+            </div>
+          ))}
+        </div>
+        {children}
+      </div>
+
+      {/* Sidebar */}
+      {sidebarOpen && (
+        <CommentSidebar
+          contractId={contractId}
+          principal={principal}
+          contractName={contractName}
+          selectedLine={selectedLine}
+          comments={comments}
+          onClose={() => {
+            setSidebarOpen(false);
+            setSelectedLine(null);
+          }}
+          onShowAll={() => setSelectedLine(null)}
+          onCommentPosted={refreshComments}
+        />
+      )}
+
+      {/* Toggle button when sidebar is closed */}
+      {!sidebarOpen && (
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="mt-3 flex items-center gap-2 rounded-lg border border-[#30363d] bg-[#161b22] px-3 py-2 text-sm text-[#8b949e] hover:text-[#c9d1d9] hover:border-[#58a6ff] transition-colors"
+        >
+          <span>Comments ({comments.length})</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,27 +1,68 @@
 export default function Footer() {
   return (
     <footer className="mt-auto border-t border-[#30363d] bg-[#0d1117] py-8">
-      <div className="mx-auto max-w-7xl px-4 text-center text-sm text-[#8b949e]">
-        <p>
-          Built by{" "}
-          <a
-            href="https://github.com/cocoa007"
-            className="text-[#58a6ff] hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            cocoa007.btc
-          </a>{" "}
-          &middot; Powered by{" "}
-          <a
-            href="https://www.hiro.so"
-            className="text-[#58a6ff] hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Hiro
-          </a>
-        </p>
+      <div className="mx-auto max-w-7xl px-4">
+        <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+          {/* Brand */}
+          <div className="flex items-center gap-2 text-sm text-[#8b949e]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/logo.svg" alt="" width={20} height={20} className="opacity-60" />
+            <span>Source of Clarity</span>
+          </div>
+
+          {/* Social links */}
+          <div className="flex items-center gap-4">
+            <a
+              href="https://github.com/cocoa007/source-of-clarity"
+              className="text-[#8b949e] hover:text-[#c9d1d9] transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+            </a>
+            <a
+              href="https://x.com/cocoa007_bot"
+              className="text-[#8b949e] hover:text-[#c9d1d9] transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="X"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a
+              href="https://bsky.app/profile/cocoa007.bsky.social"
+              className="text-[#8b949e] hover:text-[#c9d1d9] transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Bluesky"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.785 2.627 3.6 3.476 6.168 3.125-4.468.713-5.616 3.079-3.14 5.44C6.397 21.298 9.489 22 11.06 18.697c.218-.459.394-.89.527-1.283a8 8 0 00.413 1.283C13.573 22 16.665 21.298 19.41 18.812c2.476-2.361 1.328-4.727-3.14-5.44 2.568.351 5.383-.498 6.168-3.125.246-.828.624-5.788.624-6.479 0-.688-.139-1.86-.902-2.203-.659-.3-1.664-.62-4.3 1.24C15.113 4.747 12.154 8.686 12.067 10.8z"/></svg>
+            </a>
+          </div>
+
+          {/* Attribution */}
+          <div className="text-center text-sm text-[#8b949e] sm:text-right">
+            Built by{" "}
+            <a
+              href="https://github.com/cocoa007"
+              className="text-[#58a6ff] hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              cocoa007.btc
+            </a>{" "}
+            &middot; Powered by{" "}
+            <a
+              href="https://www.stacks.co"
+              className="text-[#58a6ff] hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Stacks
+            </a>
+          </div>
+        </div>
       </div>
     </footer>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,11 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import AuthButton from "./comments/AuthButton";
 
 const links = [
   { href: "/", label: "Home" },
   { href: "/contracts", label: "Contracts" },
   { href: "/audits", label: "Audits" },
+  { href: "/about", label: "About" },
 ];
 
 export default function Navbar() {
@@ -16,7 +18,8 @@ export default function Navbar() {
     <nav className="sticky top-0 z-50 border-b border-[#30363d] bg-[#0d1117]/95 backdrop-blur">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
         <Link href="/" className="flex items-center gap-2 text-lg font-bold text-[#f0f6fc]">
-          <span className="text-[#f7931a]">&#9830;</span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/logo.svg" alt="" width={28} height={28} />
           Source of Clarity
         </Link>
         <div className="flex items-center gap-6">
@@ -31,6 +34,7 @@ export default function Navbar() {
               {link.label}
             </Link>
           ))}
+          <AuthButton compact />
         </div>
       </div>
     </nav>

--- a/src/components/comments/AuthButton.tsx
+++ b/src/components/comments/AuthButton.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+
+export default function AuthButton({ compact }: { compact?: boolean }) {
+  const { user, isLoading, login, logout } = useAuth();
+  const [showForm, setShowForm] = useState(false);
+  const [identifier, setIdentifier] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  if (isLoading) {
+    return (
+      <span className="text-sm text-[#8b949e]">...</span>
+    );
+  }
+
+  if (user) {
+    if (compact) {
+      return (
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-[#58a6ff]">@{user.handle}</span>
+          <button
+            onClick={logout}
+            className="text-[#8b949e] hover:text-[#c9d1d9] text-xs"
+          >
+            Sign out
+          </button>
+        </div>
+      );
+    }
+    return (
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-[#58a6ff]">@{user.handle}</span>
+        <button
+          onClick={logout}
+          className="rounded border border-[#30363d] px-2 py-1 text-xs text-[#8b949e] hover:text-[#c9d1d9]"
+        >
+          Sign out
+        </button>
+      </div>
+    );
+  }
+
+  if (!showForm) {
+    return (
+      <button
+        onClick={() => setShowForm(true)}
+        className="rounded-lg bg-[#1185fe] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#1185fe]/90 transition-colors"
+      >
+        Sign in with Bluesky
+      </button>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSubmitting(true);
+    const result = await login(identifier, password);
+    setSubmitting(false);
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setShowForm(false);
+      setIdentifier("");
+      setPassword("");
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <input
+        type="text"
+        placeholder="handle.bsky.social"
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
+        className="rounded border border-[#30363d] bg-[#0d1117] px-3 py-1.5 text-sm text-[#c9d1d9] placeholder:text-[#484f58] focus:border-[#58a6ff] focus:outline-none"
+      />
+      <input
+        type="password"
+        placeholder="App password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="rounded border border-[#30363d] bg-[#0d1117] px-3 py-1.5 text-sm text-[#c9d1d9] placeholder:text-[#484f58] focus:border-[#58a6ff] focus:outline-none"
+      />
+      {error && <p className="text-xs text-[#f85149]">{error}</p>}
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={submitting || !identifier || !password}
+          className="rounded bg-[#1185fe] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#1185fe]/90 disabled:opacity-50"
+        >
+          {submitting ? "Signing in..." : "Sign in"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setShowForm(false);
+            setError("");
+          }}
+          className="rounded border border-[#30363d] px-3 py-1.5 text-sm text-[#8b949e] hover:text-[#c9d1d9]"
+        >
+          Cancel
+        </button>
+      </div>
+      <p className="text-[10px] text-[#484f58]">
+        Use a Bluesky app password from Settings &gt; App Passwords
+      </p>
+    </form>
+  );
+}

--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import AuthButton from "./AuthButton";
+
+interface Props {
+  principal: string;
+  contractName: string;
+  lineNumber?: number;
+  lineRange?: { start: number; end: number };
+  parentUri?: string;
+  rootUri?: string;
+  onPosted: () => void;
+}
+
+export default function CommentForm({
+  principal,
+  contractName,
+  lineNumber,
+  lineRange,
+  parentUri,
+  rootUri,
+  onPosted,
+}: Props) {
+  const { user } = useAuth();
+  const [text, setText] = useState("");
+  const [posting, setPosting] = useState(false);
+  const [error, setError] = useState("");
+
+  if (!user) {
+    return (
+      <div className="rounded-lg border border-[#30363d] bg-[#0d1117] p-3">
+        <p className="mb-2 text-sm text-[#8b949e]">Sign in to comment</p>
+        <AuthButton />
+      </div>
+    );
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!text.trim()) return;
+    setError("");
+    setPosting(true);
+
+    try {
+      const res = await fetch("/api/comments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          principal,
+          contractName,
+          text: text.trim(),
+          lineNumber,
+          lineRange,
+          parentUri,
+          rootUri,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to post comment");
+      }
+
+      setText("");
+      onPosted();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to post");
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      {lineNumber && (
+        <span className="inline-block rounded bg-[#30363d] px-2 py-0.5 text-xs text-[#8b949e]">
+          Line {lineNumber}
+        </span>
+      )}
+      {lineRange && (
+        <span className="inline-block rounded bg-[#30363d] px-2 py-0.5 text-xs text-[#8b949e]">
+          Lines {lineRange.start}-{lineRange.end}
+        </span>
+      )}
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={parentUri ? "Write a reply..." : "Write a comment..."}
+        rows={3}
+        className="w-full resize-none rounded-lg border border-[#30363d] bg-[#0d1117] px-3 py-2 text-sm text-[#c9d1d9] placeholder:text-[#484f58] focus:border-[#58a6ff] focus:outline-none"
+      />
+      {error && <p className="text-xs text-[#f85149]">{error}</p>}
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-[#484f58]">
+          Posting as @{user.handle}
+        </span>
+        <button
+          type="submit"
+          disabled={posting || !text.trim()}
+          className="rounded-lg bg-[#1185fe] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#1185fe]/90 disabled:opacity-50"
+        >
+          {posting ? "Posting..." : parentUri ? "Reply" : "Comment"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/comments/CommentSidebar.tsx
+++ b/src/components/comments/CommentSidebar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { CommentData } from "../ContractSourceInteractive";
+import CommentForm from "./CommentForm";
+import CommentThread from "./CommentThread";
+
+interface Props {
+  contractId: string;
+  principal: string;
+  contractName: string;
+  selectedLine: number | null;
+  comments: CommentData[];
+  onClose: () => void;
+  onShowAll: () => void;
+  onCommentPosted: () => void;
+}
+
+export default function CommentSidebar({
+  principal,
+  contractName,
+  selectedLine,
+  comments,
+  onClose,
+  onShowAll,
+  onCommentPosted,
+}: Props) {
+  const filtered = selectedLine
+    ? comments.filter((c) => c.lineNumber === selectedLine && !c.parentUri)
+    : comments.filter((c) => !c.parentUri);
+
+  const lineLabel = selectedLine ? `Line ${selectedLine}` : "All";
+
+  return (
+    <div className="mt-4 rounded-lg border border-[#30363d] bg-[#161b22] p-4">
+      {/* Header */}
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-[#f0f6fc]">
+            Comments
+          </h3>
+          <span className="rounded bg-[#30363d] px-2 py-0.5 text-xs text-[#8b949e]">
+            {lineLabel}
+          </span>
+          <span className="text-xs text-[#484f58]">
+            {filtered.length} comment{filtered.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {selectedLine && (
+            <button
+              onClick={onShowAll}
+              className="text-xs text-[#58a6ff] hover:underline"
+            >
+              Show all
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="text-[#8b949e] hover:text-[#c9d1d9] text-lg leading-none"
+          >
+            &times;
+          </button>
+        </div>
+      </div>
+
+      {/* New comment form */}
+      <div className="mb-4">
+        <CommentForm
+          principal={principal}
+          contractName={contractName}
+          lineNumber={selectedLine ?? undefined}
+          onPosted={onCommentPosted}
+        />
+      </div>
+
+      {/* Comment threads */}
+      <div className="space-y-1 divide-y divide-[#21262d]">
+        {filtered.length === 0 ? (
+          <p className="py-4 text-center text-sm text-[#484f58]">
+            No comments yet. Be the first!
+          </p>
+        ) : (
+          filtered.map((comment) => {
+            const replies = comments.filter(
+              (c) => c.parentUri === comment.postUri
+            );
+            return (
+              <CommentThread
+                key={comment.postUri}
+                comment={comment}
+                replies={replies}
+                allComments={comments}
+                principal={principal}
+                contractName={contractName}
+                onCommentPosted={onCommentPosted}
+              />
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/comments/CommentThread.tsx
+++ b/src/components/comments/CommentThread.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import type { CommentData } from "../ContractSourceInteractive";
+import CommentForm from "./CommentForm";
+import ReactionPicker from "./ReactionPicker";
+
+interface Props {
+  comment: CommentData;
+  replies: CommentData[];
+  allComments: CommentData[];
+  principal: string;
+  contractName: string;
+  depth?: number;
+  onCommentPosted: () => void;
+}
+
+export default function CommentThread({
+  comment,
+  replies,
+  allComments,
+  principal,
+  contractName,
+  depth = 0,
+  onCommentPosted,
+}: Props) {
+  const [showReply, setShowReply] = useState(false);
+  const maxDepth = 3;
+
+  const timeAgo = comment.createdAt
+    ? formatTimeAgo(new Date(comment.createdAt))
+    : "";
+
+  return (
+    <div
+      className={`${depth > 0 ? "ml-4 border-l border-[#21262d] pl-3" : ""}`}
+    >
+      <div className="py-2">
+        {/* Header */}
+        <div className="flex items-center gap-2 text-xs">
+          <a
+            href={`https://bsky.app/profile/${comment.authorHandle || comment.authorDid}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-[#58a6ff] hover:underline"
+          >
+            @{comment.authorHandle || comment.authorDid.slice(0, 16)}
+          </a>
+          <span className="text-[#484f58]">{timeAgo}</span>
+          {comment.lineNumber && (
+            <span className="rounded bg-[#30363d] px-1.5 py-0.5 text-[10px] text-[#8b949e]">
+              L{comment.lineNumber}
+            </span>
+          )}
+        </div>
+
+        {/* Body */}
+        <p className="mt-1 text-sm text-[#c9d1d9] whitespace-pre-wrap">
+          {comment.body}
+        </p>
+
+        {/* Actions */}
+        <div className="mt-2 flex items-center gap-3">
+          <ReactionPicker
+            commentUri={comment.postUri}
+            commentCid={comment.postCid}
+            reactions={comment.reactions}
+            userReaction={comment.userReaction}
+            onReacted={onCommentPosted}
+          />
+          {depth < maxDepth && (
+            <button
+              onClick={() => setShowReply(!showReply)}
+              className="text-xs text-[#8b949e] hover:text-[#58a6ff]"
+            >
+              {showReply ? "Cancel" : "Reply"}
+            </button>
+          )}
+        </div>
+
+        {/* Reply form */}
+        {showReply && (
+          <div className="mt-2">
+            <CommentForm
+              principal={principal}
+              contractName={contractName}
+              lineNumber={comment.lineNumber ?? undefined}
+              parentUri={comment.postUri}
+              rootUri={comment.rootUri || comment.postUri}
+              onPosted={() => {
+                setShowReply(false);
+                onCommentPosted();
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Nested replies */}
+      {replies.map((reply) => {
+        const childReplies = allComments.filter(
+          (c) => c.parentUri === reply.postUri
+        );
+        return (
+          <CommentThread
+            key={reply.postUri}
+            comment={reply}
+            replies={childReplies}
+            allComments={allComments}
+            principal={principal}
+            contractName={contractName}
+            depth={depth + 1}
+            onCommentPosted={onCommentPosted}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function formatTimeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return date.toLocaleDateString();
+}

--- a/src/components/comments/ReactionPicker.tsx
+++ b/src/components/comments/ReactionPicker.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import { ALLOWED_REACTIONS } from "@/lexicon/types";
+
+interface Props {
+  commentUri: string;
+  commentCid: string;
+  reactions: Record<string, number>;
+  userReaction?: string;
+  onReacted: () => void;
+}
+
+export default function ReactionPicker({
+  commentUri,
+  commentCid,
+  reactions,
+  userReaction,
+  onReacted,
+}: Props) {
+  const { user } = useAuth();
+
+  async function handleReact(emoji: string) {
+    if (!user) return;
+    await fetch("/api/reactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ commentUri, commentCid, emoji }),
+    });
+    onReacted();
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {ALLOWED_REACTIONS.map((emoji) => {
+        const count = reactions[emoji] || 0;
+        const isActive = userReaction === emoji;
+        if (count === 0 && !user) return null;
+        return (
+          <button
+            key={emoji}
+            onClick={() => handleReact(emoji)}
+            disabled={!user}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition-colors ${
+              isActive
+                ? "border-[#58a6ff] bg-[#58a6ff]/10 text-[#58a6ff]"
+                : "border-[#30363d] text-[#8b949e] hover:border-[#484f58]"
+            } disabled:cursor-default disabled:opacity-60`}
+          >
+            <span>{emoji}</span>
+            {count > 0 && <span>{count}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+import React from "react";
+
+interface AuthUser {
+  did: string;
+  handle: string;
+  displayName?: string;
+  avatar?: string;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isLoading: boolean;
+  login: (identifier: string, password: string) => Promise<{ error?: string }>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isLoading: true,
+  login: async () => ({}),
+  logout: async () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/auth/atproto/session")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && data.did) setUser(data);
+      })
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const login = useCallback(
+    async (identifier: string, password: string) => {
+      const res = await fetch("/api/auth/atproto/authorize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier, password }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        return { error: data.error || "Login failed" };
+      }
+      const data = await res.json();
+      setUser({ did: data.did, handle: data.handle });
+      return {};
+    },
+    []
+  );
+
+  const logout = useCallback(async () => {
+    await fetch("/api/auth/atproto/logout", { method: "POST" });
+    setUser(null);
+  }, []);
+
+  return React.createElement(
+    AuthContext.Provider,
+    { value: { user, isLoading, login, logout } },
+    children
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/lexicon/conversion.ts
+++ b/src/lexicon/conversion.ts
@@ -1,0 +1,55 @@
+import type { CommentRecord, ReactionRecord } from "./types";
+
+export function createCommentRecord(opts: {
+  principal: string;
+  name: string;
+  txId?: string;
+  text: string;
+  lineNumber?: number;
+  lineRange?: { start: number; end: number };
+  replyRef?: {
+    root: { uri: string; cid: string };
+    parent: { uri: string; cid: string };
+  };
+}): CommentRecord {
+  return {
+    subject: {
+      principal: opts.principal,
+      name: opts.name,
+      ...(opts.txId ? { txId: opts.txId } : {}),
+    },
+    text: opts.text,
+    ...(opts.lineNumber !== undefined ? { lineNumber: opts.lineNumber } : {}),
+    ...(opts.lineRange ? { lineRange: opts.lineRange } : {}),
+    ...(opts.replyRef ? { replyRef: opts.replyRef } : {}),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function createReactionRecord(opts: {
+  uri: string;
+  cid: string;
+  emoji: string;
+}): ReactionRecord {
+  return {
+    subject: { uri: opts.uri, cid: opts.cid },
+    emoji: opts.emoji,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+const BASE32_CHARS = "234567abcdefghijklmnopqrstuvwxyz";
+
+export function generateTID(): string {
+  const now = BigInt(Date.now()) * BigInt(1000);
+  const clockId = BigInt(Math.floor(Math.random() * 1024));
+  const tid = (now << BigInt(10)) | clockId;
+
+  let result = "";
+  let remaining = tid;
+  for (let i = 0; i < 13; i++) {
+    result = BASE32_CHARS[Number(remaining & BigInt(31))] + result;
+    remaining >>= BigInt(5);
+  }
+  return result;
+}

--- a/src/lexicon/types.ts
+++ b/src/lexicon/types.ts
@@ -1,0 +1,39 @@
+export const LEXICON_COMMENT = "com.source-of-clarity.temp.comment";
+export const LEXICON_REACTION = "com.source-of-clarity.temp.reaction";
+
+export interface CommentRecord {
+  subject: { principal: string; name: string; txId?: string };
+  text: string;
+  lineNumber?: number;
+  lineRange?: { start: number; end: number };
+  replyRef?: {
+    root: { uri: string; cid: string };
+    parent: { uri: string; cid: string };
+  };
+  createdAt: string;
+}
+
+export interface ReactionRecord {
+  subject: { uri: string; cid: string };
+  emoji: string;
+  createdAt: string;
+}
+
+export interface Comment extends CommentRecord {
+  uri: string;
+  cid: string;
+  authorDid: string;
+  authorHandle?: string;
+  reactions: Record<string, number>;
+  userReaction?: string;
+  replyCount: number;
+}
+
+export const ALLOWED_REACTIONS = [
+  "\u{1F44D}",
+  "\u{2764}\u{FE0F}",
+  "\u{1F525}",
+  "\u{1F440}",
+  "\u{1F680}",
+  "\u{26A0}\u{FE0F}",
+];

--- a/src/lexicon/validation.ts
+++ b/src/lexicon/validation.ts
@@ -1,0 +1,54 @@
+import type { CommentRecord } from "./types";
+import { ALLOWED_REACTIONS } from "./types";
+
+export function isValidCommentRecord(
+  record: unknown
+): record is CommentRecord {
+  if (!record || typeof record !== "object") return false;
+  const r = record as Record<string, unknown>;
+
+  if (
+    !r.subject ||
+    typeof r.subject !== "object" ||
+    !("principal" in (r.subject as object)) ||
+    !("name" in (r.subject as object))
+  )
+    return false;
+
+  if (typeof r.text !== "string" || r.text.length === 0 || r.text.length > 10000)
+    return false;
+
+  if (typeof r.createdAt !== "string") return false;
+
+  if (r.lineNumber !== undefined && (typeof r.lineNumber !== "number" || r.lineNumber < 1))
+    return false;
+
+  if (r.lineRange !== undefined && !isValidLineRange(r.lineRange)) return false;
+
+  return true;
+}
+
+export function isValidLineRange(
+  range: unknown
+): range is { start: number; end: number } {
+  if (!range || typeof range !== "object") return false;
+  const r = range as Record<string, unknown>;
+  return (
+    typeof r.start === "number" &&
+    typeof r.end === "number" &&
+    r.start >= 1 &&
+    r.end >= r.start
+  );
+}
+
+export function isValidReactionEmoji(emoji: string): boolean {
+  return ALLOWED_REACTIONS.includes(emoji);
+}
+
+export function getCommentType(
+  record: CommentRecord
+): "contract" | "line" | "range" {
+  if (record.lineRange) return "range";
+  if (record.lineNumber) return "line";
+  return "contract";
+}

--- a/src/lib/atproto-auth.ts
+++ b/src/lib/atproto-auth.ts
@@ -1,0 +1,119 @@
+import crypto from "crypto";
+
+const SESSION_SECRET =
+  process.env.ATPROTO_SESSION_SECRET || "default-dev-secret-change-in-prod!!";
+
+interface SessionData {
+  did: string;
+  handle: string;
+  accessJwt: string;
+  refreshJwt: string;
+}
+
+export function encryptSession(data: SessionData): string {
+  const iv = crypto.randomBytes(16);
+  const key = crypto.scryptSync(SESSION_SECRET, "salt", 32);
+  const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+  let encrypted = cipher.update(JSON.stringify(data), "utf8", "base64");
+  encrypted += cipher.final("base64");
+  return iv.toString("base64") + "." + encrypted;
+}
+
+export function decryptSession(token: string): SessionData | null {
+  try {
+    const [ivB64, encrypted] = token.split(".");
+    if (!ivB64 || !encrypted) return null;
+    const iv = Buffer.from(ivB64, "base64");
+    const key = crypto.scryptSync(SESSION_SECRET, "salt", 32);
+    const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
+    let decrypted = decipher.update(encrypted, "base64", "utf8");
+    decrypted += decipher.final("utf8");
+    return JSON.parse(decrypted);
+  } catch {
+    return null;
+  }
+}
+
+export function getSessionFromCookies(
+  cookieHeader: string | null
+): SessionData | null {
+  if (!cookieHeader) return null;
+  const match = cookieHeader.match(/atproto_session=([^;]+)/);
+  if (!match) return null;
+  return decryptSession(decodeURIComponent(match[1]));
+}
+
+export function makeSessionCookie(data: SessionData): string {
+  const encrypted = encryptSession(data);
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  return `atproto_session=${encodeURIComponent(encrypted)}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${60 * 60 * 24 * 7}${secure}`;
+}
+
+export function clearSessionCookie(): string {
+  return "atproto_session=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0";
+}
+
+export async function resolveHandleToDid(
+  handle: string
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handle)}`
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.did || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function createSession(
+  identifier: string,
+  password: string
+): Promise<SessionData | null> {
+  try {
+    const res = await fetch(
+      "https://bsky.social/xrpc/com.atproto.server.createSession",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier, password }),
+      }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      did: data.did,
+      handle: data.handle,
+      accessJwt: data.accessJwt,
+      refreshJwt: data.refreshJwt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function refreshSession(
+  refreshJwt: string
+): Promise<SessionData | null> {
+  try {
+    const res = await fetch(
+      "https://bsky.social/xrpc/com.atproto.server.refreshSession",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${refreshJwt}` },
+      }
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      did: data.did,
+      handle: data.handle,
+      accessJwt: data.accessJwt,
+      refreshJwt: data.refreshJwt,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/clarity.tmLanguage.json
+++ b/src/lib/clarity.tmLanguage.json
@@ -1,0 +1,381 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "clarity",
+  "scopeName": "source.clar",
+  "uuid": "f9e9871d-2ea6-4be0-afd2-fc382d704716",
+  "patterns": [
+    { "include": "#expression" },
+    { "include": "#define-constant" },
+    { "include": "#define-data-var" },
+    { "include": "#define-map" },
+    { "include": "#define-function" },
+    { "include": "#define-fungible-token" },
+    { "include": "#define-non-fungible-token" },
+    { "include": "#define-trait" },
+    { "include": "#use-trait" }
+  ],
+  "repository": {
+    "comment": {
+      "name": "comment.line.semicolon.clarity",
+      "match": "(?x) (?<=^|[()\\[\\]{}\",'`;\\s]) (;) .* $"
+    },
+    "expression": {
+      "patterns": [
+        { "include": "#comment" },
+        { "include": "#keyword" },
+        { "include": "#literal" },
+        { "include": "#let-func" },
+        { "include": "#built-in-func" },
+        { "include": "#get-set-func" }
+      ]
+    },
+    "keyword": {
+      "name": "constant.language.clarity",
+      "match": "(?<!\\S)(?!-)\\b(?:block-height|burn-block-height|chain-id|contract-caller|is-in-regtest|stacks-block-height|stx-liquid-supply|tenure-height|tx-sender|tx-sponsor?|current-contract|stacks-block-time)\\b(?!\\s*-)"
+    },
+    "define-function": {
+      "begin": "(?x) (\\() \\s* (define-(?:public|private|read-only)) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.define-function.start.clarity" },
+        "2": { "name": "keyword.declaration.define-function.clarity" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.define-function.end.clarity" }
+      },
+      "name": "meta.define-function",
+      "patterns": [
+        { "include": "#expression" },
+        {
+          "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\?\\!\\-]*) \\s*",
+          "end": "(\\))",
+          "beginCaptures": {
+            "1": { "name": "punctuation.function-signature.start.clarity" },
+            "2": { "name": "entity.name.function.clarity" }
+          },
+          "endCaptures": {
+            "1": { "name": "punctuation.function-signature.end.clarity" }
+          },
+          "name": "meta.define-function-signature",
+          "patterns": [
+            {
+              "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+              "end": "(\\))",
+              "beginCaptures": {
+                "1": { "name": "punctuation.function-argument.start.clarity" },
+                "2": { "name": "variable.parameter.clarity" }
+              },
+              "endCaptures": {
+                "1": { "name": "punctuation.function-argument.end.clarity" }
+              },
+              "name": "meta.function-argument",
+              "patterns": [{ "include": "#data-type" }]
+            }
+          ]
+        },
+        { "include": "#user-func" }
+      ]
+    },
+    "define-fungible-token": {
+      "match": "(?x) (\\() \\s* (define-fungible-token) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) (?:\\s+(u\\d+))?",
+      "captures": {
+        "1": { "name": "punctuation.define-fungible-token.start.clarity" },
+        "2": { "name": "keyword.declaration.define-fungible-token.clarity" },
+        "3": { "name": "entity.name.fungible-token-name.clarity variable.other.clarity" },
+        "4": { "name": "constant.numeric.fungible-token-total-supply.clarity" }
+      }
+    },
+    "define-non-fungible-token": {
+      "begin": "(?x) (\\() \\s* (define-non-fungible-token) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.define-non-fungible-token.start.clarity" },
+        "2": { "name": "keyword.declaration.define-non-fungible-token.clarity" },
+        "3": { "name": "entity.name.non-fungible-token-name.clarity variable.other.clarity" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.define-non-fungible-token.end.clarity" }
+      },
+      "name": "meta.define-non-fungible-token",
+      "patterns": [{ "include": "#data-type" }]
+    },
+    "define-trait": {
+      "begin": "(?x) (\\() \\s* (define-trait) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.define-trait.start.clarity" },
+        "2": { "name": "keyword.declaration.define-trait.clarity" },
+        "3": { "name": "entity.name.trait-name.clarity variable.other.clarity" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.define-trait.end.clarity" }
+      },
+      "name": "meta.define-trait",
+      "patterns": [
+        {
+          "begin": "(?x) (\\() \\s*",
+          "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.define-trait-body.start.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.define-trait-body.end.clarity" } },
+          "name": "meta.define-trait-body",
+          "patterns": [
+            { "include": "#expression" },
+            {
+              "begin": "(?x) (\\() \\s* ([a-zA-Z][\\w\\!\\?\\-]*) \\s+",
+              "end": "(\\))",
+              "beginCaptures": {
+                "1": { "name": "punctuation.trait-function.start.clarity" },
+                "2": { "name": "entity.name.function.clarity" }
+              },
+              "endCaptures": { "1": { "name": "punctuation.trait-function.end.clarity" } },
+              "name": "meta.trait-function",
+              "patterns": [
+                { "include": "#data-type" },
+                {
+                  "begin": "(?x) (\\() \\s*",
+                  "end": "(\\))",
+                  "beginCaptures": { "1": { "name": "punctuation.trait-function-args.start.clarity" } },
+                  "endCaptures": { "1": { "name": "punctuation.trait-function-args.end.clarity" } },
+                  "name": "meta.trait-function-args",
+                  "patterns": [{ "include": "#data-type" }]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "use-trait": {
+      "begin": "(?x) (\\() \\s* (use-trait) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.use-trait.start.clarity" },
+        "2": { "name": "keyword.declaration.use-trait.clarity" },
+        "3": { "name": "entity.name.trait-alias.clarity variable.other.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.use-trait.end.clarity" } },
+      "name": "meta.use-trait",
+      "patterns": [{ "include": "#literal" }]
+    },
+    "define-constant": {
+      "begin": "(?x) (\\() \\s* (define-constant) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.define-constant.start.clarity" },
+        "2": { "name": "keyword.declaration.define-constant.clarity" },
+        "3": { "name": "entity.name.constant-name.clarity variable.other.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.define-constant.end.clarity" } },
+      "name": "meta.define-constant",
+      "patterns": [{ "include": "#expression" }]
+    },
+    "define-data-var": {
+      "begin": "(?x) (\\() \\s* (define-data-var) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.define-data-var.start.clarity" },
+        "2": { "name": "keyword.declaration.define-data-var.clarity" },
+        "3": { "name": "entity.name.data-var-name.clarity variable.other.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.define-data-var.end.clarity" } },
+      "name": "meta.define-data-var",
+      "patterns": [{ "include": "#data-type" }, { "include": "#expression" }]
+    },
+    "define-map": {
+      "begin": "(?x) (\\() \\s* (define-map) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.define-map.start.clarity" },
+        "2": { "name": "keyword.declaration.define-map.clarity" },
+        "3": { "name": "entity.name.map-name.clarity variable.other.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.define-map.end.clarity" } },
+      "name": "meta.define-map",
+      "patterns": [{ "include": "#data-type" }, { "include": "#expression" }]
+    },
+    "literal": {
+      "patterns": [
+        { "include": "#number-literal" },
+        { "include": "#bool-literal" },
+        { "include": "#string-literal" },
+        { "include": "#tuple-literal" },
+        { "include": "#principal-literal" },
+        { "include": "#list-literal" },
+        { "include": "#optional-literal" },
+        { "include": "#response-literal" }
+      ],
+      "repository": {
+        "number-literal": {
+          "patterns": [
+            { "name": "constant.numeric.uint.clarity", "match": "(?<!\\S)(?!-)\\bu\\d+\\b(?!\\s*-)" },
+            { "name": "constant.numeric.int.clarity", "match": "(?<!\\S)(?!-)\\b\\d+\\b(?!\\s*-)" },
+            { "name": "constant.numeric.hex.clarity", "match": "(?<!\\S)(?!-)\\b0x[0-9a-f]*\\b(?!\\s*-)" }
+          ]
+        },
+        "bool-literal": { "name": "constant.language.bool.clarity", "match": "(?<!\\S)(?!-)\\b(true|false)\\b(?!\\s*-)" },
+        "string-literal": {
+          "patterns": [{
+            "name": "string.quoted.double.clarity",
+            "begin": "(u?)(\")",
+            "beginCaptures": { "1": { "name": "string.quoted.utf8.clarity" }, "2": { "name": "punctuation.definition.string.begin.clarity" } },
+            "end": "\"",
+            "endCaptures": { "1": { "name": "punctuation.definition.string.end.clarity" } },
+            "patterns": [{ "name": "constant.character.escape.quote", "match": "\\\\." }]
+          }]
+        },
+        "tuple-literal": {
+          "begin": "(\\{)", "end": "(\\})",
+          "beginCaptures": { "1": { "name": "punctuation.tuple.start.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.tuple.end.clarity" } },
+          "name": "meta.tuple",
+          "patterns": [
+            { "name": "entity.name.tag.tuple-key.clarity", "match": "([a-zA-Z][\\w\\?\\!\\-]*)(?=:)" },
+            { "include": "#expression" },
+            { "include": "#user-func" }
+          ]
+        },
+        "principal-literal": {
+          "name": "constant.other.principal.clarity",
+          "match": "(?x)  \\'[0-9A-Z]{28,41}(:?\\.[a-zA-Z][a-zA-Z0-9\\-]+){0,2} | (\\.[a-zA-Z][a-zA-Z0-9\\-]*){1,2} (?=[\\s(){},]|$)"
+        },
+        "list-literal": {
+          "begin": "(?x) (\\() \\s* (list) \\s+", "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.list.start.clarity" }, "2": { "name": "entity.name.type.list.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.list.end.clarity" } },
+          "name": "meta.list",
+          "patterns": [{ "include": "#expression" }, { "include": "#user-func" }]
+        },
+        "optional-literal": {
+          "patterns": [
+            { "match": "(?<!\\S)(?!-)\\b(none)\\b(?!\\s*-)", "name": "constant.language.none.clarity" },
+            {
+              "begin": "(?x) (\\() \\s* (some) \\s+", "end": "(\\))",
+              "beginCaptures": { "1": { "name": "punctuation.some.start.clarity" }, "2": { "name": "constant.language.some.clarity" } },
+              "endCaptures": { "1": { "name": "punctuation.some.end.clarity" } },
+              "name": "meta.some",
+              "patterns": [{ "include": "#expression" }]
+            }
+          ]
+        },
+        "response-literal": {
+          "begin": "(?x) (\\() \\s* (ok|err) \\s+", "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.response.start.clarity" }, "2": { "name": "constant.language.ok-err.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.response.end.clarity" } },
+          "name": "meta.response",
+          "patterns": [{ "include": "#expression" }, { "include": "#user-func" }]
+        }
+      }
+    },
+    "data-type": {
+      "patterns": [
+        { "include": "#comment" },
+        { "name": "entity.name.type.numeric.clarity", "match": "\\b(uint|int)\\b" },
+        { "name": "entity.name.type.principal.clarity", "match": "\\b(principal)\\b" },
+        { "name": "entity.name.type.bool.clarity", "match": "\\b(bool)\\b" },
+        {
+          "match": "(?x) (\\() \\s* (?:(string-ascii|string-utf8)\\s+(\\d+)) \\s* (\\))",
+          "captures": { "1": { "name": "punctuation.string_type-def.start.clarity" }, "2": { "name": "entity.name.type.string_type.clarity" }, "3": { "name": "constant.numeric.string_type-len.clarity" }, "4": { "name": "punctuation.string_type-def.end.clarity" } }
+        },
+        {
+          "match": "(?x) (\\() \\s* (buff)\\s+(\\d+)\\s* (\\))",
+          "captures": { "1": { "name": "punctuation.buff-def.start.clarity" }, "2": { "name": "entity.name.type.buff.clarity" }, "3": { "name": "constant.numeric.buf-len.clarity" }, "4": { "name": "punctuation.buff-def.end.clarity" } }
+        },
+        {
+          "begin": "(?x) (\\() \\s* (optional)\\s+", "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.optional-def.start.clarity" }, "2": { "name": "storage.type.modifier" } },
+          "endCaptures": { "1": { "name": "punctuation.optional-def.end.clarity" } },
+          "name": "meta.optional-def",
+          "patterns": [{ "include": "#data-type" }]
+        },
+        {
+          "begin": "(?x) (\\() \\s* (response)\\s+", "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.response-def.start.clarity" }, "2": { "name": "storage.type.modifier" } },
+          "endCaptures": { "1": { "name": "punctuation.response-def.end.clarity" } },
+          "name": "meta.response-def",
+          "patterns": [{ "include": "#data-type" }]
+        },
+        {
+          "begin": "(?x) (\\() \\s* (list) \\s+ (\\d+) \\s+", "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.list-def.start.clarity" }, "2": { "name": "entity.name.type.list.clarity" }, "3": { "name": "constant.numeric.list-len.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.list-def.end.clarity" } },
+          "name": "meta.list-def",
+          "patterns": [{ "include": "#data-type" }]
+        },
+        {
+          "begin": "(\\{)", "end": "(\\})",
+          "beginCaptures": { "1": { "name": "punctuation.tuple-def.start.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.tuple-def.end.clarity" } },
+          "name": "meta.tuple-def",
+          "patterns": [
+            { "name": "entity.name.tag.tuple-data-type-key.clarity", "match": "([a-zA-Z][\\w\\?\\!\\-]*)(?=:)" },
+            { "include": "#data-type" }
+          ]
+        }
+      ]
+    },
+    "built-in-func": {
+      "begin": "(?x) (\\() \\s* (\\-|\\+|<\\=|>\\=|<|>|\\*|/|and|append|as-contract|as-contract\\?|as-max-len\\?|asserts!|at-block|begin|bit-and|bit-not|bit-or|bit-shift-left|bit-shift-right|bit-xor|buff-to-int-be|buff-to-int-le|buff-to-uint-be|buff-to-uint-le|concat|contract-call\\?|contract-of|default-to|element-at|element-at\\?|filter|fold|from-consensus-buff\\?|ft-burn\\?|ft-get-balance|ft-get-supply|ft-mint\\?|ft-transfer\\?|get-block-info\\?|get-burn-block-info\\?|get-stacks-block-info\\?|get-tenure-info\\?|hash160|if|impl-trait|index-of|index-of\\?|int-to-ascii|int-to-utf8|is-eq|is-err|is-none|is-ok|is-some|is-standard|keccak256|len|log2|map|match|merge|mod|nft-burn\\?|nft-get-owner\\?|nft-mint\\?|nft-transfer\\?|not|or|pow|principal-construct\\?|principal-destruct\\?|principal-of\\?|print|replace-at\\?|secp256k1-recover\\?|secp256k1-verify|sha256|sha512|sha512/256|slice\\?|sqrti|string-to-int\\?|string-to-uint\\?|to-ascii\\?|stx-account|stx-burn\\?|stx-get-balance|stx-transfer-memo\\?|stx-transfer\\?|to-consensus-buff\\?|to-int|to-uint|try!|unwrap!|unwrap-err!|unwrap-err-panic|unwrap-panic|xor) \\s+",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.built-in-function.start.clarity" },
+        "2": { "name": "keyword.declaration.built-in-function.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.built-in-function.end.clarity" } },
+      "name": "meta.built-in-function",
+      "patterns": [{ "include": "#expression" }, { "include": "#user-func" }]
+    },
+    "get-set-func": {
+      "begin": "(?x) (\\() \\s* (var-get|var-set|map-get\\?|map-set|map-insert|map-delete|get) \\s+ ([a-zA-Z][\\w\\?\\!\\-]*) \\s*",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.get-set-func.start.clarity" },
+        "2": { "name": "keyword.control.clarity" },
+        "3": { "name": "variable.other.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.get-set-func.end.clarity" } },
+      "name": "meta.get-set-func",
+      "patterns": [{ "include": "#expression" }]
+    },
+    "let-func": {
+      "begin": "(?x) (\\() \\s* (let) \\s*",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.let-function.start.clarity" },
+        "2": { "name": "keyword.declaration.let-function.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.let-function.end.clarity" } },
+      "name": "meta.let-function",
+      "patterns": [
+        { "include": "#expression" },
+        { "include": "#user-func" },
+        {
+          "begin": "(?x) (\\() \\s*", "end": "(\\))",
+          "beginCaptures": { "1": { "name": "punctuation.let-var.start.clarity" } },
+          "endCaptures": { "1": { "name": "punctuation.let-var.end.clarity" } },
+          "name": "meta.let-var",
+          "patterns": [
+            {
+              "begin": "(?x) (\\() ([a-zA-Z][\\w\\?\\!\\-]*) \\s+", "end": "(\\))",
+              "beginCaptures": { "1": { "name": "punctuation.let-local-var.start.clarity" }, "2": { "name": "entity.name.let-local-var-name.clarity variable.parameter.clarity" } },
+              "endCaptures": { "1": { "name": "punctuation.let-local-var.end.clarity" } },
+              "name": "meta.let-local-var",
+              "patterns": [{ "include": "#expression" }, { "include": "#user-func" }]
+            },
+            { "include": "#expression" }
+          ]
+        }
+      ]
+    },
+    "user-func": {
+      "begin": "(?x) (\\() \\s* (([a-zA-Z][\\w\\?\\!\\-]*)) \\s*",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.user-function.start.clarity" },
+        "2": { "name": "entity.name.function.clarity" }
+      },
+      "endCaptures": { "1": { "name": "punctuation.user-function.end.clarity" } },
+      "name": "meta.user-function",
+      "patterns": [{ "include": "#expression" }, { "include": "$self" }]
+    }
+  }
+}

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -1,0 +1,154 @@
+import { db } from "./db";
+import { comments, reactions } from "./schema";
+import { eq, and, sql, desc } from "drizzle-orm";
+
+export async function getCommentsByContract(contractId: string) {
+  const rows = await db
+    .select()
+    .from(comments)
+    .where(eq(comments.contractId, contractId))
+    .orderBy(desc(comments.createdAt));
+
+  if (rows.length === 0) return [];
+
+  const uris = rows.map((r) => r.postUri);
+  const reactionRows = await db
+    .select({
+      commentUri: reactions.commentUri,
+      emoji: reactions.emoji,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(reactions)
+    .where(sql`${reactions.commentUri} = ANY(${uris})`)
+    .groupBy(reactions.commentUri, reactions.emoji);
+
+  const reactionMap = new Map<string, Record<string, number>>();
+  for (const r of reactionRows) {
+    if (!reactionMap.has(r.commentUri)) reactionMap.set(r.commentUri, {});
+    reactionMap.get(r.commentUri)![r.emoji] = r.count;
+  }
+
+  const replyCounts = new Map<string, number>();
+  for (const row of rows) {
+    if (row.parentUri) {
+      replyCounts.set(row.parentUri, (replyCounts.get(row.parentUri) || 0) + 1);
+    }
+  }
+
+  return rows.map((row) => ({
+    ...row,
+    reactions: reactionMap.get(row.postUri) || {},
+    replyCount: replyCounts.get(row.postUri) || 0,
+  }));
+}
+
+export async function getCommentCountsByLine(
+  contractId: string
+): Promise<Record<number, number>> {
+  const rows = await db
+    .select({
+      lineNumber: comments.lineNumber,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(comments)
+    .where(
+      and(
+        eq(comments.contractId, contractId),
+        sql`${comments.lineNumber} IS NOT NULL`
+      )
+    )
+    .groupBy(comments.lineNumber);
+
+  const result: Record<number, number> = {};
+  for (const row of rows) {
+    if (row.lineNumber !== null) result[row.lineNumber] = row.count;
+  }
+  return result;
+}
+
+export async function getCommentByUri(uri: string) {
+  const rows = await db
+    .select()
+    .from(comments)
+    .where(eq(comments.postUri, uri))
+    .limit(1);
+  return rows[0] || null;
+}
+
+export async function insertComment(data: {
+  contractId: string;
+  principal: string;
+  contractName: string;
+  lineNumber?: number;
+  lineRangeStart?: number;
+  lineRangeEnd?: number;
+  authorDid: string;
+  authorHandle?: string;
+  postUri: string;
+  postCid: string;
+  parentUri?: string;
+  rootUri?: string;
+  body: string;
+}) {
+  const rows = await db.insert(comments).values(data).returning();
+  return rows[0];
+}
+
+export async function upsertReaction(data: {
+  commentUri: string;
+  authorDid: string;
+  emoji: string;
+  postUri: string;
+}) {
+  const existing = await db
+    .select()
+    .from(reactions)
+    .where(
+      and(
+        eq(reactions.commentUri, data.commentUri),
+        eq(reactions.authorDid, data.authorDid)
+      )
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    if (existing[0].emoji === data.emoji) {
+      await db.delete(reactions).where(eq(reactions.id, existing[0].id));
+      return { action: "removed" as const, oldUri: existing[0].postUri };
+    }
+    await db
+      .update(reactions)
+      .set({ emoji: data.emoji, postUri: data.postUri })
+      .where(eq(reactions.id, existing[0].id));
+    return { action: "updated" as const, oldUri: existing[0].postUri };
+  }
+
+  await db.insert(reactions).values(data);
+  return { action: "created" as const, oldUri: null };
+}
+
+export async function deleteReactionByUri(postUri: string) {
+  await db.delete(reactions).where(eq(reactions.postUri, postUri));
+}
+
+export async function getUserReactions(commentUris: string[], authorDid: string) {
+  if (commentUris.length === 0) return {};
+  const rows = await db
+    .select({
+      commentUri: reactions.commentUri,
+      emoji: reactions.emoji,
+      postUri: reactions.postUri,
+    })
+    .from(reactions)
+    .where(
+      and(
+        sql`${reactions.commentUri} = ANY(${commentUris})`,
+        eq(reactions.authorDid, authorDid)
+      )
+    );
+  const result: Record<string, { emoji: string; postUri: string }> = {};
+  for (const r of rows) {
+    result[r.commentUri] = { emoji: r.emoji, postUri: r.postUri };
+  }
+  return result;
+}

--- a/src/lib/contracts.ts
+++ b/src/lib/contracts.ts
@@ -23,11 +23,13 @@ export async function searchContracts(opts: {
   sip009?: boolean;
   sip010?: boolean;
   deployer?: string;
+  network?: string;
   page?: number;
   limit?: number;
 }) {
-  const { query, sip009, sip010, deployer, page = 1, limit = 24 } = opts;
+  const { query, sip009, sip010, deployer, network = "mainnet", page = 1, limit = 24 } = opts;
   const conditions = [];
+  conditions.push(eq(contracts.network, network));
 
   if (query) {
     conditions.push(
@@ -44,7 +46,11 @@ export async function searchContracts(opts: {
   const where = conditions.length > 0 ? and(...conditions) : undefined;
   const offset = (page - 1) * limit;
 
-  const [rows, countResult] = await Promise.all([
+  const queries: [
+    Promise<(typeof contracts.$inferSelect)[]>,
+    Promise<{ count: number }[]>,
+    Promise<{ contractId: string; functionName: string; access: string }[]>,
+  ] = [
     db
       .select()
       .from(contracts)
@@ -56,31 +62,48 @@ export async function searchContracts(opts: {
       .select({ count: sql<number>`count(*)::int` })
       .from(contracts)
       .where(where),
-  ]);
+    // Search functions by name when there's a query
+    query
+      ? db
+          .select({
+            contractId: contractFunctions.contractId,
+            functionName: contractFunctions.name,
+            access: contractFunctions.access,
+          })
+          .from(contractFunctions)
+          .where(ilike(contractFunctions.name, `%${query}%`))
+          .limit(20)
+      : Promise.resolve([]),
+  ];
+
+  const [rows, countResult, functionMatches] = await Promise.all(queries);
 
   return {
     contracts: rows,
     total: countResult[0]?.count || 0,
     page,
     totalPages: Math.ceil((countResult[0]?.count || 0) / limit),
+    functionMatches,
   };
 }
 
-export async function getContractStats() {
+export async function getContractStats(network = "mainnet") {
   const result = await db
     .select({
       total: sql<number>`count(*)::int`,
       nftCount: sql<number>`count(*) filter (where sip_009 = true)::int`,
       ftCount: sql<number>`count(*) filter (where sip_010 = true)::int`,
     })
-    .from(contracts);
+    .from(contracts)
+    .where(eq(contracts.network, network));
   return result[0];
 }
 
-export async function getRecentContracts(limit = 10) {
+export async function getRecentContracts(limit = 10, network = "mainnet") {
   return db
     .select()
     .from(contracts)
+    .where(eq(contracts.network, network))
     .orderBy(desc(contracts.blockHeight))
     .limit(limit);
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -27,6 +27,7 @@ export const contracts = pgTable(
     sip010: boolean("sip_010").default(false),
     functionCount: integer("function_count").default(0),
     protocol: text("protocol"),
+    network: text("network").default("mainnet").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
   },
   (table) => [
@@ -34,6 +35,7 @@ export const contracts = pgTable(
     index("idx_contracts_block_height").on(table.blockHeight),
     index("idx_contracts_sip009").on(table.sip009),
     index("idx_contracts_sip010").on(table.sip010),
+    index("idx_contracts_network").on(table.network),
   ]
 );
 
@@ -90,6 +92,48 @@ export const auditFindings = pgTable("audit_findings", {
   recommendation: text("recommendation"),
   codeSnippet: text("code_snippet"),
 });
+
+export const comments = pgTable(
+  "comments",
+  {
+    id: serial("id").primaryKey(),
+    contractId: text("contract_id").notNull(),
+    principal: text("principal").notNull(),
+    contractName: text("contract_name").notNull(),
+    lineNumber: integer("line_number"),
+    lineRangeStart: integer("line_range_start"),
+    lineRangeEnd: integer("line_range_end"),
+    authorDid: text("author_did").notNull(),
+    authorHandle: text("author_handle"),
+    postUri: text("post_uri").notNull().unique(),
+    postCid: text("post_cid").notNull(),
+    parentUri: text("parent_uri"),
+    rootUri: text("root_uri"),
+    body: text("body").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    index("idx_comments_contract_id").on(table.contractId),
+    index("idx_comments_contract_line").on(table.contractId, table.lineNumber),
+    index("idx_comments_parent_uri").on(table.parentUri),
+  ]
+);
+
+export const reactions = pgTable(
+  "reactions",
+  {
+    id: serial("id").primaryKey(),
+    commentUri: text("comment_uri").notNull(),
+    authorDid: text("author_did").notNull(),
+    emoji: text("emoji").notNull(),
+    postUri: text("post_uri").notNull().unique(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    index("idx_reactions_comment_uri").on(table.commentUri),
+    index("idx_reactions_comment_author").on(table.commentUri, table.authorDid),
+  ]
+);
 
 export const auditJobs = pgTable("audit_jobs", {
   id: serial("id").primaryKey(),


### PR DESCRIPTION
## Summary

- **Brand:** New diamond+Stacks logo, "Clarity, clarified." tagline, enhanced hero with feature pillars, CSS color system, OG/Twitter card images (site-level and per-contract dynamic)
- **AT Protocol comments:** Bluesky sign-in (app passwords), line-level code comments, threaded replies, emoji reactions, stored on user's PDS with local PostgreSQL cache
- **Clarity syntax highlighting:** Full TextMate grammar from code-love-social with proper keyword/function/literal support
- **Audit layout fix:** Audits without parsed findings now render htmlContent with proper styling instead of showing empty severity bars
- **Function search:** Contract search now also matches Clarity function names, displayed as clickable chips
- **Testnet support:** New `network` column on contracts table, filter chip on contracts page, API param
- **Auth fix:** Secure cookie flag for HTTPS, better error messages
- **Branding updates:** Hiro replaced with Stacks, aibtc.dev replaced with aibtc.com, SVG social icons in footer
- **New pages:** About page, launch content drafts

## Test plan

- [ ] Visit `/` — verify new logo, tagline, feature pillars render
- [ ] Visit `/contracts?q=transfer` — verify function matches appear above contract grid
- [ ] Visit `/contracts?network=testnet` — verify testnet filter chip works
- [ ] Visit `/audit/aegis-quest-escrow` — verify severity bars and findings still render
- [ ] Visit any other audit — verify htmlContent renders with proper styling
- [ ] Click "Sign in with Bluesky" — verify auth form appears
- [ ] Share a contract URL — verify OG image previews
- [ ] Check favicon in browser tab — verify diamond+Stacks icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)