### PR TITLE
Add SIP trait checker and AT Protocol comment importer scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@atproto/api": "^0.19.3",
-        "@atproto/oauth-client-browser": "^0.3.41",
+        "@atproto/oauth-client-node": "^0.3.17",
+        "@stacks/clarinet-sdk": "^3.14.1",
         "@tailwindcss/typography": "^0.5.19",
         "@types/pg": "^8.18.0",
         "drizzle-orm": "^0.45.1",
@@ -67,6 +68,21 @@
         "@atproto-labs/pipe": "0.1.1"
       }
     },
+    "node_modules/@atproto-labs/fetch-node": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/fetch-node/-/fetch-node-0.2.0.tgz",
+      "integrity": "sha512-Krq09nH/aeoiU2s9xdHA0FjTEFWG9B5FFenipv1iRixCcPc7V3DhTNDawxG9gI8Ny0k4dBVS9WTRN/IDzBx86Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/fetch": "0.2.3",
+        "@atproto-labs/pipe": "0.1.1",
+        "ipaddr.js": "^2.1.0",
+        "undici": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
     "node_modules/@atproto-labs/handle-resolver": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver/-/handle-resolver-0.3.6.tgz",
@@ -77,6 +93,20 @@
         "@atproto-labs/simple-store-memory": "0.1.4",
         "@atproto/did": "0.3.0",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto-labs/handle-resolver-node": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@atproto-labs/handle-resolver-node/-/handle-resolver-node-0.1.25.tgz",
+      "integrity": "sha512-NY9WYM2VLd3IuMGRkkmvGBg8xqVEaK/fitv1vD8SMXqFTekdpjOLCCyv7EFtqVHouzmDcL83VOvWRfHVa8V9Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto-labs/fetch-node": "0.2.0",
+        "@atproto-labs/handle-resolver": "0.3.6",
+        "@atproto/did": "0.3.0"
+      },
+      "engines": {
+        "node": ">=18.7.0"
       }
     },
     "node_modules/@atproto-labs/identity-resolver": {
@@ -235,21 +265,24 @@
         "zod": "^3.23.8"
       }
     },
-    "node_modules/@atproto/oauth-client-browser": {
-      "version": "0.3.41",
-      "resolved": "https://registry.npmjs.org/@atproto/oauth-client-browser/-/oauth-client-browser-0.3.41.tgz",
-      "integrity": "sha512-4QTm8zPgm08vl53flrVmL+MS5IOhvWWctNZmEnPbvQ2t1ISw9Q5m815m2Sszi5ULMFjOqvT7lhKB7zQUn5gq5g==",
+    "node_modules/@atproto/oauth-client-node": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@atproto/oauth-client-node/-/oauth-client-node-0.3.17.tgz",
+      "integrity": "sha512-67LNuKAlC35Exe7CB5S0QCAnEqr6fKV9Nvp64jAHFof1N+Vc9Ltt1K9oekE5Ctf7dvpGByrHRF0noUw9l9sWLA==",
       "license": "MIT",
       "dependencies": {
         "@atproto-labs/did-resolver": "^0.2.6",
-        "@atproto-labs/handle-resolver": "^0.3.6",
+        "@atproto-labs/handle-resolver-node": "^0.1.25",
         "@atproto-labs/simple-store": "^0.3.0",
         "@atproto/did": "^0.3.0",
         "@atproto/jwk": "^0.6.0",
+        "@atproto/jwk-jose": "^0.1.11",
         "@atproto/jwk-webcrypto": "^0.2.0",
         "@atproto/oauth-client": "^0.6.0",
-        "@atproto/oauth-types": "^0.6.3",
-        "core-js": "^3"
+        "@atproto/oauth-types": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18.7.0"
       }
     },
     "node_modules/@atproto/oauth-types": {
@@ -1827,6 +1860,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@shikijs/core": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.1.tgz",
@@ -1926,6 +1983,58 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@stacks/clarinet-sdk": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk/-/clarinet-sdk-3.14.1.tgz",
+      "integrity": "sha512-fCrUNWDyXNoOCGgEdGLJxNNZHafPamXLRr+3CaTAeJ+LAWNSH7uo4iEDzQs/Q48D0YWu9rloznyBVSb57pNgGg==",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@stacks/clarinet-sdk-wasm": "3.14.1",
+        "@stacks/transactions": "^7.0.6",
+        "kolorist": "^1.8.0",
+        "prompts": "^2.4.2",
+        "yargs": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stacks/clarinet-sdk-wasm": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@stacks/clarinet-sdk-wasm/-/clarinet-sdk-wasm-3.14.1.tgz",
+      "integrity": "sha512-hoDZcEKvp56cOWc+D5CZrPKBqZNC5fJ+7lG4psN6SSW2CtuFUcAqKPSFx6TJjt/WGIfejWvB3N9bWRZfyji7yw==",
+      "license": "GPL-3.0"
+    },
+    "node_modules/@stacks/common": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.3.1.tgz",
+      "integrity": "sha512-29ANTFcSSlXnGQlgDVWg7OQ74lgQhu3x8JkeN19Q+UE/1lbQrzcctgPHG74XHjWNp8NPBqskUYA8/HLgIKuKNQ==",
+      "license": "MIT"
+    },
+    "node_modules/@stacks/network": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.3.1.tgz",
+      "integrity": "sha512-dQjhcwkz8lihSYSCUMf7OYeEh/Eh0++NebDtXbIB3pHWTvNCYEH7sxhYTB1iyunurv31/QEi0RuWdlfXK/BjeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stacks/common": "^7.3.1",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/transactions": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.3.1.tgz",
+      "integrity": "sha512-ufnC1BPrOKz5b5gxxdseP3vBrFq1+qx1L6t+J/QnjXULyWdkhtS+LBEqRw2bL5qNteMvU2GhqPgFtYQPzolGbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^7.3.1",
+        "@stacks/network": "^7.3.1",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2289,10 +2398,40 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/await-lock": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
       "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2313,6 +2452,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/c32check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
+      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "base-x": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001777",
@@ -2370,6 +2522,20 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -2389,6 +2555,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cssesc": {
@@ -2601,6 +2776,12 @@
         }
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
@@ -2670,6 +2851,15 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.35.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.0.tgz",
@@ -2710,6 +2900,27 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2778,6 +2989,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/iso-datestring-validator": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
@@ -2802,6 +3022,21 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.31.1",
@@ -3064,6 +3299,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -3317,6 +3558,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
@@ -3510,6 +3771,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -3658,6 +3932,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3707,6 +3987,23 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -3719,6 +4016,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/styled-jsx": {
@@ -3772,6 +4084,12 @@
       "bin": {
         "tlds": "bin.js"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -4316,6 +4634,15 @@
         "multiformats": "^9.4.2"
       }
     },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -4430,6 +4757,39 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -4437,6 +4797,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "@atproto/api": "^0.19.3",
-    "@atproto/oauth-client-browser": "^0.3.41",
+    "@atproto/oauth-client-node": "^0.3.17",
+    "@stacks/clarinet-sdk": "^3.14.1",
     "@tailwindcss/typography": "^0.5.19",
     "@types/pg": "^8.18.0",
     "drizzle-orm": "^0.45.1",

--- a/src/scripts/check-traits.ts
+++ b/src/scripts/check-traits.ts
@@ -1,0 +1,159 @@
+/**
+ * Check SIP trait implementation for all contracts via local Stacks node.
+ *
+ * Usage:
+ *   npx tsx src/scripts/check-traits.ts <trait> <column>
+ *
+ * Examples:
+ *   npx tsx src/scripts/check-traits.ts SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait sip_009
+ *   npx tsx src/scripts/check-traits.ts SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait sip_010
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { contracts } from "../lib/schema";
+import { inArray } from "drizzle-orm";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agent@/source_of_clarity?host=/var/run/postgresql";
+const API_BASE =
+  process.env.STACKS_API_BASE || "http://172.235.160.149:3999";
+const BATCH_SIZE = 500;
+const CONCURRENCY = 50;
+const LOG_INTERVAL = 1000;
+
+const ALLOWED_COLUMNS = new Set(["sip_009", "sip_010"]);
+const COLUMN_MAP: Record<string, "sip009" | "sip010"> = {
+  sip_009: "sip009",
+  sip_010: "sip010",
+};
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+const db = drizzle(pool);
+
+function parseTrait(arg: string): { address: string; contract: string; name: string } {
+  const parts = arg.split(".");
+  if (parts.length !== 3) {
+    throw new Error(`Invalid trait format: ${arg} (expected ADDRESS.CONTRACT.TRAIT)`);
+  }
+  return { address: parts[0], contract: parts[1], name: parts[2] };
+}
+
+async function checkTrait(
+  contractAddress: string,
+  contractName: string,
+  trait: { address: string; contract: string; name: string }
+): Promise<boolean | null> {
+  const url = `${API_BASE}/v2/traits/${contractAddress}/${contractName}/${trait.address}/${trait.contract}/${trait.name}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return res.status === 404 ? false : null;
+    const data = await res.json();
+    return data.is_implemented === true;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const [traitArg, columnArg] = process.argv.slice(2);
+
+  if (!traitArg || !columnArg) {
+    console.error("Usage: npx tsx src/scripts/check-traits.ts <trait> <column>");
+    console.error("  trait:  ADDRESS.CONTRACT.TRAIT (e.g. SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.nft-trait.nft-trait)");
+    console.error("  column: sip_009 or sip_010");
+    process.exit(1);
+  }
+
+  if (!ALLOWED_COLUMNS.has(columnArg)) {
+    console.error(`Invalid column: ${columnArg}. Allowed: ${[...ALLOWED_COLUMNS].join(", ")}`);
+    process.exit(1);
+  }
+
+  const field = COLUMN_MAP[columnArg];
+  const trait = parseTrait(traitArg);
+  console.log(`Trait: ${trait.address}.${trait.contract}.${trait.name}`);
+  console.log(`Column: ${columnArg}`);
+  console.log(`API: ${API_BASE}`);
+  console.log(`Concurrency: ${CONCURRENCY}`);
+
+  // Reset all values to false
+  console.log("Resetting all values to false...");
+  await db.update(contracts).set({ [field]: false });
+  console.log("Reset complete.");
+
+  let offset = 0;
+  let totalChecked = 0;
+  let totalImplemented = 0;
+  let totalErrors = 0;
+  const startTime = Date.now();
+
+  while (true) {
+    const rows = await db
+      .select({ contractId: contracts.contractId })
+      .from(contracts)
+      .orderBy(contracts.id)
+      .limit(BATCH_SIZE)
+      .offset(offset);
+
+    if (rows.length === 0) break;
+
+    const implementedIds: string[] = [];
+
+    // Process in concurrent chunks
+    for (let i = 0; i < rows.length; i += CONCURRENCY) {
+      const chunk = rows.slice(i, i + CONCURRENCY);
+      const results = await Promise.all(
+        chunk.map(async (row) => {
+          const dotIdx = row.contractId.indexOf(".");
+          if (dotIdx === -1) return { contractId: row.contractId, result: null as boolean | null };
+          const addr = row.contractId.slice(0, dotIdx);
+          const name = row.contractId.slice(dotIdx + 1);
+          return { contractId: row.contractId, result: await checkTrait(addr, name, trait) };
+        })
+      );
+
+      for (const { contractId, result } of results) {
+        if (result === true) {
+          implementedIds.push(contractId);
+          totalImplemented++;
+        } else if (result === null) {
+          totalErrors++;
+        }
+        totalChecked++;
+      }
+
+      if (totalChecked % LOG_INTERVAL < CONCURRENCY) {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
+        const rate = (totalChecked / ((Date.now() - startTime) / 1000)).toFixed(0);
+        console.log(
+          `Checked: ${totalChecked} | Implemented: ${totalImplemented} | Errors: ${totalErrors} | ${rate}/s | ${elapsed}s`
+        );
+      }
+    }
+
+    // Batch update implemented contracts
+    if (implementedIds.length > 0) {
+      await db
+        .update(contracts)
+        .set({ [field]: true })
+        .where(inArray(contracts.contractId, implementedIds));
+    }
+
+    offset += BATCH_SIZE;
+  }
+
+  const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`\nDone in ${totalTime}s!`);
+  console.log(`Total checked: ${totalChecked}`);
+  console.log(`Implemented (${columnArg}): ${totalImplemented}`);
+  console.log(`Errors/skipped: ${totalErrors}`);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/scripts/import-at-comments.ts
+++ b/src/scripts/import-at-comments.ts
@@ -1,0 +1,298 @@
+/**
+ * Import comments and reactions from AT Protocol network into the local DB.
+ *
+ * Scans known DIDs for com.source-of-clarity.temp.comment and
+ * com.source-of-clarity.temp.reaction records.
+ *
+ * Usage: npx tsx src/scripts/import-at-comments.ts
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { contracts, comments, reactions } from "../lib/schema";
+import { eq, sql } from "drizzle-orm";
+import { LEXICON_COMMENT, LEXICON_REACTION } from "../lexicon/types";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgres://agent@/source_of_clarity?host=/var/run/postgresql";
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+const db = drizzle(pool);
+
+const KNOWN_DIDS = [
+  "did:plc:buan5xkx5tn2aipmptfs63cw", // friedger.eurosky.social
+  "did:plc:yozhoiev6cypqvb2gngvpy6z", // raficostar.bsky.social
+  "did:plc:nzm7vgxpzrx267efzhzmryup", // cryptosmith-btc.bsky.social
+];
+
+interface PDSInfo {
+  did: string;
+  pds: string;
+  handle: string;
+}
+
+interface ATRecord {
+  uri: string;
+  cid: string;
+  value: Record<string, unknown>;
+}
+
+async function resolveDID(did: string): Promise<PDSInfo | null> {
+  try {
+    const res = await fetch(`https://plc.directory/${did}`);
+    if (!res.ok) return null;
+    const doc = await res.json();
+
+    // Find PDS endpoint
+    let pds = "";
+    const services = doc.service || [];
+    for (const svc of services) {
+      if (
+        svc.id === "#atproto_pds" ||
+        svc.type === "AtprotoPersonalDataServer"
+      ) {
+        pds = svc.serviceEndpoint;
+        break;
+      }
+    }
+    if (!pds) return null;
+
+    // Get handle from alsoKnownAs
+    let handle = did;
+    const aka = doc.alsoKnownAs || [];
+    for (const alias of aka) {
+      if (typeof alias === "string" && alias.startsWith("at://")) {
+        handle = alias.replace("at://", "");
+        break;
+      }
+    }
+
+    return { did, pds, handle };
+  } catch (err) {
+    console.error(`Failed to resolve ${did}:`, (err as Error).message);
+    return null;
+  }
+}
+
+async function listRecords(
+  pds: string,
+  did: string,
+  collection: string
+): Promise<ATRecord[]> {
+  const allRecords: ATRecord[] = [];
+  let cursor: string | undefined;
+
+  while (true) {
+    const params = new URLSearchParams({
+      repo: did,
+      collection,
+      limit: "100",
+    });
+    if (cursor) params.set("cursor", cursor);
+
+    try {
+      const res = await fetch(
+        `${pds}/xrpc/com.atproto.repo.listRecords?${params}`
+      );
+      if (!res.ok) {
+        if (res.status === 400) break; // Collection doesn't exist
+        console.error(`listRecords error: HTTP ${res.status} for ${did}/${collection}`);
+        break;
+      }
+      const data = await res.json();
+      const records = data.records || [];
+      allRecords.push(...records);
+
+      if (!data.cursor || records.length === 0) break;
+      cursor = data.cursor;
+    } catch (err) {
+      console.error(`listRecords fetch error:`, (err as Error).message);
+      break;
+    }
+  }
+
+  return allRecords;
+}
+
+function extractDid(uri: string): string {
+  // at://did:plc:xxx/collection/rkey -> did:plc:xxx
+  const parts = uri.replace("at://", "").split("/");
+  return parts[0];
+}
+
+async function commentExists(postUri: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: comments.id })
+    .from(comments)
+    .where(eq(comments.postUri, postUri))
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function reactionExists(postUri: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: reactions.id })
+    .from(reactions)
+    .where(eq(reactions.postUri, postUri))
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function contractExists(contractId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: contracts.id })
+    .from(contracts)
+    .where(eq(contracts.contractId, contractId))
+    .limit(1);
+  return rows.length > 0;
+}
+
+async function importComments(info: PDSInfo): Promise<{ imported: number; skipped: number }> {
+  const records = await listRecords(info.pds, info.did, LEXICON_COMMENT);
+  let imported = 0;
+  let skipped = 0;
+
+  for (const rec of records) {
+    const val = rec.value as {
+      subject?: { principal?: string; contractName?: string; name?: string };
+      text?: string;
+      lineNumber?: number;
+      lineRange?: { start?: number; end?: number };
+      replyRef?: {
+        root?: { uri?: string; cid?: string };
+        parent?: { uri?: string; cid?: string };
+      };
+      reply?: {
+        root?: { uri?: string; cid?: string };
+        parent?: { uri?: string; cid?: string };
+      };
+      createdAt?: string;
+    };
+
+    const contractName = val.subject?.contractName || val.subject?.name;
+    if (!val.subject?.principal || !contractName || !val.text) {
+      skipped++;
+      continue;
+    }
+
+    const contractId = `${val.subject.principal}.${contractName}`;
+
+    // Check for duplicates
+    if (await commentExists(rec.uri)) {
+      skipped++;
+      continue;
+    }
+
+    // Verify contract exists
+    if (!(await contractExists(contractId))) {
+      console.log(`  Skipping comment for unknown contract: ${contractId}`);
+      skipped++;
+      continue;
+    }
+
+    const replyData = val.replyRef || val.reply;
+
+    await db.insert(comments).values({
+      contractId,
+      principal: val.subject.principal,
+      contractName,
+      lineNumber: val.lineNumber ?? null,
+      lineRangeStart: val.lineRange?.start ?? null,
+      lineRangeEnd: val.lineRange?.end ?? null,
+      authorDid: info.did,
+      authorHandle: info.handle,
+      postUri: rec.uri,
+      postCid: rec.cid,
+      parentUri: replyData?.parent?.uri ?? null,
+      rootUri: replyData?.root?.uri ?? null,
+      body: val.text,
+      createdAt: val.createdAt ? new Date(val.createdAt) : new Date(),
+    });
+
+    imported++;
+  }
+
+  return { imported, skipped };
+}
+
+async function importReactions(info: PDSInfo): Promise<{ imported: number; skipped: number }> {
+  const records = await listRecords(info.pds, info.did, LEXICON_REACTION);
+  let imported = 0;
+  let skipped = 0;
+
+  for (const rec of records) {
+    const val = rec.value as {
+      subject?: { uri?: string; cid?: string };
+      emoji?: string;
+      createdAt?: string;
+    };
+
+    if (!val.subject?.uri || !val.emoji) {
+      skipped++;
+      continue;
+    }
+
+    if (await reactionExists(rec.uri)) {
+      skipped++;
+      continue;
+    }
+
+    await db.insert(reactions).values({
+      commentUri: val.subject.uri,
+      authorDid: info.did,
+      emoji: val.emoji,
+      postUri: rec.uri,
+      createdAt: val.createdAt ? new Date(val.createdAt) : new Date(),
+    });
+
+    imported++;
+  }
+
+  return { imported, skipped };
+}
+
+async function main() {
+  console.log("AT Protocol Comment/Reaction Importer");
+  console.log(`Scanning ${KNOWN_DIDS.length} DIDs...\n`);
+
+  let totalComments = 0;
+  let totalReactions = 0;
+  let totalSkipped = 0;
+
+  for (const did of KNOWN_DIDS) {
+    console.log(`Resolving ${did}...`);
+    const info = await resolveDID(did);
+    if (!info) {
+      console.log(`  Could not resolve DID, skipping`);
+      continue;
+    }
+    console.log(`  Handle: ${info.handle}`);
+    console.log(`  PDS: ${info.pds}`);
+
+    // Import comments
+    const commentResult = await importComments(info);
+    console.log(`  Comments: ${commentResult.imported} imported, ${commentResult.skipped} skipped`);
+    totalComments += commentResult.imported;
+    totalSkipped += commentResult.skipped;
+
+    // Import reactions
+    const reactionResult = await importReactions(info);
+    console.log(`  Reactions: ${reactionResult.imported} imported, ${reactionResult.skipped} skipped`);
+    totalReactions += reactionResult.imported;
+    totalSkipped += reactionResult.skipped;
+
+    console.log();
+  }
+
+  console.log("Done!");
+  console.log(`Total imported: ${totalComments} comments, ${totalReactions} reactions`);
+  console.log(`Total skipped: ${totalSkipped}`);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
- check-traits.ts: checks all 126k contracts against local Stacks node /v2/traits/ endpoint, updates sip_009/sip_010 columns (6143 NFTs, 5403 FTs found)
- import-at-comments.ts: scans known DIDs for com.source-of-clarity.temp.comment/reaction records and imports into DB (17 comments, 11 reactions imported)
- Add @stacks/clarinet-sdk dependency