### PR TITLE
fix: harden auth, pagination, and ownership checks

### DIFF
--- a/src/app/api/chainhook/route.ts
+++ b/src/app/api/chainhook/route.ts
@@ -3,11 +3,15 @@ import { processChainhookPayload } from "@/lib/chainhook";
 
 export async function POST(request: NextRequest) {
   const authToken = process.env.CHAINHOOK_AUTH_TOKEN;
-  if (authToken) {
-    const provided = request.headers.get("authorization")?.replace("Bearer ", "");
-    if (provided !== authToken) {
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    }
+  if (!authToken) {
+    return NextResponse.json(
+      { error: "CHAINHOOK_AUTH_TOKEN not configured" },
+      { status: 500 }
+    );
+  }
+  const provided = request.headers.get("authorization")?.replace("Bearer ", "");
+  if (provided !== authToken) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
   try {

--- a/src/app/api/contracts/route.ts
+++ b/src/app/api/contracts/route.ts
@@ -3,14 +3,16 @@ import { searchContracts } from "@/lib/contracts";
 
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
+  const page = Math.max(1, parseInt(params.get("page") || "1", 10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(params.get("limit") || "24", 10) || 24));
   const result = await searchContracts({
     query: params.get("q") || undefined,
     sip009: params.get("sip009") === "1",
     sip010: params.get("sip010") === "1",
     deployer: params.get("deployer") || undefined,
     network: params.get("network") === "testnet" ? "testnet" : "mainnet",
-    page: parseInt(params.get("page") || "1", 10),
-    limit: parseInt(params.get("limit") || "24", 10),
+    page,
+    limit,
   });
   return NextResponse.json(result);
 }

--- a/src/app/api/reactions/route.ts
+++ b/src/app/api/reactions/route.ts
@@ -130,7 +130,7 @@ export async function DELETE(request: NextRequest) {
     }).catch(() => {});
   }
 
-  await deleteReactionByUri(reactionUri);
+  await deleteReactionByUri(reactionUri, session.did);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/lib/atproto-auth.ts
+++ b/src/lib/atproto-auth.ts
@@ -1,7 +1,12 @@
 import crypto from "crypto";
 
-const SESSION_SECRET =
-  process.env.ATPROTO_SESSION_SECRET || "default-dev-secret-change-in-prod!!";
+const SESSION_SECRET = process.env.ATPROTO_SESSION_SECRET;
+if (!SESSION_SECRET) {
+  throw new Error(
+    "ATPROTO_SESSION_SECRET environment variable is required. " +
+    "Generate one with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\""
+  );
+}
 
 interface SessionData {
   did: string;

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -127,8 +127,10 @@ export async function upsertReaction(data: {
   return { action: "created" as const, oldUri: null };
 }
 
-export async function deleteReactionByUri(postUri: string) {
-  await db.delete(reactions).where(eq(reactions.postUri, postUri));
+export async function deleteReactionByUri(postUri: string, authorDid: string) {
+  await db
+    .delete(reactions)
+    .where(and(eq(reactions.postUri, postUri), eq(reactions.authorDid, authorDid)));
 }
 
 export async function getUserReactions(commentUris: string[], authorDid: string) {


### PR DESCRIPTION
## Summary

Fixes #7, #8, #9 — security hardening for auth, API pagination, and access control.

- **#7 — Session secret fallback removed**: `atproto-auth.ts` no longer falls back to a hardcoded default when `ATPROTO_SESSION_SECRET` is missing. It now throws a clear error at startup with instructions to generate one.
- **#8 — Chainhook auth enforced**: `chainhook/route.ts` now returns 500 if `CHAINHOOK_AUTH_TOKEN` is not configured (previously could allow unauthenticated access).
- **#9 — Pagination bounds + ownership check**: `contracts/route.ts` clamps `page >= 1` and `1 <= limit <= 100`. `reactions/route.ts` DELETE now passes `session.did` to `deleteReactionByUri`, and `comments.ts` filters by `authorDid` so users can only delete their own reactions.

## Files changed

| File | Change |
|------|--------|
| `src/lib/atproto-auth.ts` | Remove insecure default, require env var |
| `src/app/api/chainhook/route.ts` | Require auth token config |
| `src/app/api/contracts/route.ts` | Bound pagination params |
| `src/app/api/reactions/route.ts` | Pass authorDid to delete |
| `src/lib/comments.ts` | Add ownership filter to deleteReactionByUri |

## Test plan

- [ ] Verify app fails to start without `ATPROTO_SESSION_SECRET` set
- [ ] Verify chainhook POST returns 500 without `CHAINHOOK_AUTH_TOKEN`
- [ ] Verify chainhook POST returns 401 with wrong token
- [ ] Verify `?page=-1&limit=9999` gets clamped to `page=1, limit=100`
- [ ] Verify reaction DELETE only removes reactions owned by the session user

🤖 Generated with [Claude Code](https://claude.com/claude-code)